### PR TITLE
feat: v2 Player — multi-URL failover, honest failure classification, liveness hint

### DIFF
--- a/app/src/components/ChannelCard.tsx
+++ b/app/src/components/ChannelCard.tsx
@@ -1,9 +1,8 @@
 import { Link } from '@tanstack/react-router'
 import type { Channel } from '../data/types'
+import { isPlausiblyLive } from '../data/status'
 
 type Mode = 'compact' | 'full'
-
-const DEAD = new Set(['error', 'timeout', 'blocked', 'offline'])
 
 // Deterministic accent colour from the channel name (logo-fallback avatar).
 function hueFromName(name: string): number {
@@ -13,9 +12,8 @@ function hueFromName(name: string): number {
 }
 
 function Liveness({ channel }: { channel: Channel }) {
-  const status = channel.streams[0]?.status
   // Best-effort hint only; suppress when unknown or known-dead (no false "LIVE").
-  if (!status || status === 'unknown' || DEAD.has(status)) return null
+  if (!isPlausiblyLive(channel.streams[0]?.status)) return null
   return <span aria-label="recently online" title="recently online" className="inline-block h-2 w-2 rounded-full bg-green-500" />
 }
 

--- a/app/src/components/LivenessHint.tsx
+++ b/app/src/components/LivenessHint.tsx
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react'
+import type { Stream } from '../data/types'
+import { livenessHint } from '../lib/liveness'
+
+// Client-only liveness hint. The relative time depends on `now`, which differs
+// between the SSR render and hydration — computing it during render produces a
+// hydration mismatch and a visible text patch. So we render nothing on the
+// server / first paint and fill it in after mount. The hint is decorative
+// (not SEO content), so deferring it costs nothing.
+export function LivenessHint({ stream }: { stream: Stream | undefined }) {
+  const [text, setText] = useState<string | null>(null)
+  useEffect(() => {
+    setText(livenessHint(stream, new Date())?.text ?? null)
+  }, [stream])
+
+  if (!text) return null
+  return (
+    <p className="text-xs text-gray-400" title="best-effort — streams are checked about daily">
+      {text}
+    </p>
+  )
+}

--- a/app/src/components/Player.test.tsx
+++ b/app/src/components/Player.test.tsx
@@ -1,22 +1,160 @@
-import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
 import { Player } from './Player'
-import type { Channel } from '../data/types'
+import type { Channel, Stream } from '../data/types'
 
-function channel(streams: Channel['streams']): Channel {
+// Controllable hls.js fake: records instances so tests can emit MANIFEST_PARSED /
+// fatal ERROR and assert loadSource/destroy. (vi.hoisted so the mock factory and
+// the test body share the same registry.)
+const hlsMock = vi.hoisted(() => {
+  const instances: Array<{
+    config: unknown
+    handlers: Record<string, (e: unknown, data: unknown) => void>
+    loadSource: ReturnType<typeof vi.fn>
+    attachMedia: ReturnType<typeof vi.fn>
+    destroy: ReturnType<typeof vi.fn>
+    emit: (event: string, data?: unknown) => void
+  }> = []
+  class FakeHls {
+    config: unknown
+    handlers: Record<string, (e: unknown, data: unknown) => void> = {}
+    loadSource = vi.fn()
+    attachMedia = vi.fn()
+    stopLoad = vi.fn()
+    detachMedia = vi.fn()
+    destroy = vi.fn()
+    constructor(config: unknown) {
+      this.config = config
+      instances.push(this as never)
+    }
+    on(event: string, cb: (e: unknown, data: unknown) => void) {
+      this.handlers[event] = cb
+    }
+    emit(event: string, data?: unknown) {
+      this.handlers[event]?.(event, data)
+    }
+    static Events = { MANIFEST_PARSED: 'hlsManifestParsed', ERROR: 'hlsError' }
+    static isSupported = vi.fn(() => true)
+  }
+  return { instances, FakeHls }
+})
+vi.mock('hls.js', () => ({ default: hlsMock.FakeHls }))
+
+function stream(url: string, overrides: Partial<Stream> = {}): Stream {
+  const scheme = url.startsWith('https') ? 'https' : 'http'
+  return { url, status: 'online', checkedAt: null, scheme, likelyPlayable: true, quality: null, ...overrides }
+}
+function channel(streams: Stream[]): Channel {
   return { id: 'x', name: 'X', country: 'gb', categories: [], languages: [], logo: null, guide: null, playable: true, streams }
 }
+function video() {
+  return screen.getByTestId('player').querySelector('video') as HTMLVideoElement
+}
+
+let originalLocation: PropertyDescriptor | undefined
+function setProtocol(protocol: string) {
+  originalLocation = Object.getOwnPropertyDescriptor(window, 'location')
+  Object.defineProperty(window, 'location', { configurable: true, value: { protocol, href: `${protocol}//localhost/` } })
+}
+
+beforeEach(() => {
+  hlsMock.instances.length = 0
+  hlsMock.FakeHls.isSupported.mockReturnValue(true)
+  // jsdom doesn't implement media playback — stub to keep the console quiet.
+  HTMLMediaElement.prototype.play = vi.fn().mockResolvedValue(undefined)
+  HTMLMediaElement.prototype.load = vi.fn()
+})
+afterEach(() => {
+  cleanup()
+  if (originalLocation) {
+    Object.defineProperty(window, 'location', originalLocation)
+    originalLocation = undefined
+  }
+})
 
 describe('Player', () => {
-  it('renders a video element when a stream URL exists', () => {
-    render(<Player channel={channel([{ url: 'https://x/y.m3u8', status: 'online', checkedAt: null, scheme: 'https', likelyPlayable: true, quality: null }])} />)
+  it('renders a video element when a stream URL exists', async () => {
+    render(<Player channel={channel([stream('https://x/y.m3u8')])} />)
     expect(screen.getByTestId('player')).toBeTruthy()
-    expect(document.querySelector('video')).toBeTruthy()
+    expect(video()).toBeTruthy()
+    await waitFor(() => expect(hlsMock.instances).toHaveLength(1))
   })
 
   it('shows a no-stream message when there are no streams', () => {
     render(<Player channel={channel([])} />)
     expect(screen.getByText(/No stream available/i)).toBeTruthy()
     expect(screen.queryByTestId('player')).toBeNull()
+  })
+
+  it('plays the first stream and offers an unmute affordance once playing', async () => {
+    render(<Player channel={channel([stream('https://x/first.m3u8')])} />)
+    await waitFor(() => expect(hlsMock.instances).toHaveLength(1))
+    expect(hlsMock.instances[0].loadSource).toHaveBeenCalledWith('https://x/first.m3u8')
+    hlsMock.instances[0].emit('hlsManifestParsed')
+    fireEvent.loadedMetadata(video())
+    await waitFor(() => expect(screen.getByTestId('player-unmute')).toBeTruthy())
+    expect(screen.queryByTestId('player-error')).toBeNull()
+  })
+
+  it('fails over to the second URL on a fatal error without showing an error card', async () => {
+    render(<Player channel={channel([stream('https://x/first.m3u8'), stream('https://x/second.m3u8')])} />)
+    await waitFor(() => expect(hlsMock.instances).toHaveLength(1))
+    hlsMock.instances[0].emit('hlsError', { fatal: true, type: 'networkError', details: 'manifestLoadError', response: { code: 404 } })
+    await waitFor(() => expect(hlsMock.instances).toHaveLength(2))
+    expect(hlsMock.instances[0].destroy).toHaveBeenCalled()
+    expect(hlsMock.instances[1].loadSource).toHaveBeenCalledWith('https://x/second.m3u8')
+    expect(screen.queryByTestId('player-error')).toBeNull()
+  })
+
+  it('classifies an http-only stream on an https page as browser-blocked without touching hls.js', async () => {
+    setProtocol('https:')
+    render(<Player channel={channel([stream('http://x/only.m3u8')])} />)
+    await waitFor(() => expect(screen.getByTestId('player-error')).toBeTruthy())
+    expect(hlsMock.instances).toHaveLength(0)
+    expect(screen.getByTestId('player-error').textContent).toMatch(/blocked or unreachable/i)
+    expect(screen.getByTestId('player-retry')).toBeTruthy()
+  })
+
+  it('shows the region-restricted message when all streams return 403', async () => {
+    render(<Player channel={channel([stream('https://x/a.m3u8'), stream('https://x/b.m3u8')])} />)
+    await waitFor(() => expect(hlsMock.instances).toHaveLength(1))
+    hlsMock.instances[0].emit('hlsError', { fatal: true, type: 'networkError', details: 'manifestLoadError', response: { code: 403 } })
+    await waitFor(() => expect(hlsMock.instances).toHaveLength(2))
+    hlsMock.instances[1].emit('hlsError', { fatal: true, type: 'networkError', details: 'manifestLoadError', response: { code: 403 } })
+    await waitFor(() => expect(screen.getByTestId('player-error')).toBeTruthy())
+    expect(screen.getByTestId('player-error').textContent).toMatch(/region-restricted/i)
+  })
+
+  it('shows exactly one honest failure card with a retry and no playing video when exhausted', async () => {
+    render(<Player channel={channel([stream('https://x/only.m3u8')])} />)
+    await waitFor(() => expect(hlsMock.instances).toHaveLength(1))
+    hlsMock.instances[0].emit('hlsError', { fatal: true, type: 'networkError', details: 'manifestLoadError', response: { code: 410 } })
+    await waitFor(() => expect(screen.getByTestId('player-error')).toBeTruthy())
+    expect(screen.getAllByTestId('player-error')).toHaveLength(1)
+    expect(screen.getByTestId('player-retry')).toBeTruthy()
+    expect(screen.getByTestId('player').querySelector('video')).toBeNull()
+  })
+
+  it('retries from the first URL when the user clicks Try again', async () => {
+    render(<Player channel={channel([stream('https://x/first.m3u8')])} />)
+    await waitFor(() => expect(hlsMock.instances).toHaveLength(1))
+    hlsMock.instances[0].emit('hlsError', { fatal: true, type: 'networkError', details: 'manifestLoadError', response: { code: 404 } })
+    await waitFor(() => expect(screen.getByTestId('player-retry')).toBeTruthy())
+    fireEvent.click(screen.getByTestId('player-retry'))
+    await waitFor(() => expect(hlsMock.instances).toHaveLength(2))
+    expect(hlsMock.instances[1].loadSource).toHaveBeenCalledWith('https://x/first.m3u8')
+  })
+
+  it('tears down hls.js on unmount', async () => {
+    const { unmount } = render(<Player channel={channel([stream('https://x/only.m3u8')])} />)
+    await waitFor(() => expect(hlsMock.instances).toHaveLength(1))
+    unmount()
+    expect(hlsMock.instances[0].destroy).toHaveBeenCalled()
+  })
+
+  it('falls over to honest failure when hls.js is unsupported', async () => {
+    hlsMock.FakeHls.isSupported.mockReturnValue(false)
+    render(<Player channel={channel([stream('https://x/only.m3u8')])} />)
+    await waitFor(() => expect(screen.getByTestId('player-error')).toBeTruthy())
   })
 })

--- a/app/src/components/Player.test.tsx
+++ b/app/src/components/Player.test.tsx
@@ -91,9 +91,25 @@ describe('Player', () => {
     await waitFor(() => expect(hlsMock.instances).toHaveLength(1))
     expect(hlsMock.instances[0].loadSource).toHaveBeenCalledWith('https://x/first.m3u8')
     hlsMock.instances[0].emit('hlsManifestParsed')
-    fireEvent.loadedMetadata(video())
+    fireEvent.canPlay(video())
     await waitFor(() => expect(screen.getByTestId('player-unmute')).toBeTruthy())
     expect(screen.queryByTestId('player-error')).toBeNull()
+  })
+
+  it('does not settle on loadedmetadata alone, so a later fatal error still fails over', async () => {
+    render(<Player channel={channel([stream('https://x/first.m3u8'), stream('https://x/second.m3u8')])} />)
+    await waitFor(() => expect(hlsMock.instances).toHaveLength(1))
+    // Metadata parses, but no `canplay` — then the segments fail fatally.
+    fireEvent.loadedMetadata(video())
+    hlsMock.instances[0].emit('hlsError', { fatal: true, type: 'networkError', details: 'fragLoadError', response: { code: 403 } })
+    await waitFor(() => expect(hlsMock.instances).toHaveLength(2))
+    expect(hlsMock.instances[1].loadSource).toHaveBeenCalledWith('https://x/second.m3u8')
+  })
+
+  it('shows the no-stream message when the only stream has an empty URL', () => {
+    render(<Player channel={channel([stream('')])} />)
+    expect(screen.getByText(/No stream available/i)).toBeTruthy()
+    expect(screen.queryByTestId('player')).toBeNull()
   })
 
   it('fails over to the second URL on a fatal error without showing an error card', async () => {

--- a/app/src/components/Player.tsx
+++ b/app/src/components/Player.tsx
@@ -87,6 +87,10 @@ export function Player({ channel }: { channel: Channel }) {
       if (deadline) clearTimeout(deadline)
       deadline = undefined
     }
+    // Per-URL wall-clock guard: if nothing becomes playable in time, fail over.
+    const armDeadline = () => {
+      deadline = setTimeout(() => fail('dead'), DEADLINE_MS)
+    }
     const teardownHls = () => {
       if (hls) {
         try {
@@ -155,7 +159,7 @@ export function Player({ channel }: { channel: Channel }) {
       if (video.canPlayType('application/vnd.apple.mpegurl')) {
         video.src = c.url
         tryPlayMuted()
-        deadline = setTimeout(() => fail('dead'), DEADLINE_MS)
+        armDeadline()
         return
       }
 
@@ -185,7 +189,7 @@ export function Player({ channel }: { channel: Channel }) {
           })
           instance.loadSource(c.url)
           instance.attachMedia(video)
-          deadline = setTimeout(() => fail('dead'), DEADLINE_MS)
+          armDeadline()
         })
         .catch(() => {
           if (!cancelled && myId === attemptId) fail('dead')
@@ -195,14 +199,13 @@ export function Player({ channel }: { channel: Channel }) {
     // First playable signal from the media element = success (true for both the
     // hls.js and native paths; survives autoplay being blocked, since metadata
     // loads regardless of whether playback was allowed to start audibly).
-    const onPlayable = () => markPlaying()
     // Native-path error (the hls.js path classifies via its own ERROR event).
     const onNativeError = () => {
       if (hls) return
       fail(classifyFailure({ scheme: candidates[idx]?.scheme ?? 'https' }, pageProtocol, online))
     }
-    video.addEventListener('loadedmetadata', onPlayable)
-    video.addEventListener('playing', onPlayable)
+    video.addEventListener('loadedmetadata', markPlaying)
+    video.addEventListener('playing', markPlaying)
     video.addEventListener('error', onNativeError)
 
     attempt()
@@ -210,12 +213,15 @@ export function Player({ channel }: { channel: Channel }) {
     return () => {
       cancelled = true
       clearDeadline()
-      video.removeEventListener('loadedmetadata', onPlayable)
-      video.removeEventListener('playing', onPlayable)
+      video.removeEventListener('loadedmetadata', markPlaying)
+      video.removeEventListener('playing', markPlaying)
       video.removeEventListener('error', onNativeError)
       teardownHls()
     }
-  }, [channel.id, retryToken, hasStreams, streams])
+    // streams/hasStreams are invariant for a given channel.id; depending on the
+    // streams array ref would tear down and rebuild the player on any re-render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [channel.id, retryToken])
 
   if (!hasStreams) {
     return <p className="rounded bg-gray-100 p-4 text-sm text-gray-600">No stream available for this channel.</p>

--- a/app/src/components/Player.tsx
+++ b/app/src/components/Player.tsx
@@ -55,7 +55,8 @@ export function Player({ channel }: { channel: Channel }) {
   const [muted, setMuted] = useState(true)
   const [retryToken, setRetryToken] = useState(0)
 
-  const streams = channel.streams
+  // Drop streams with no usable URL up front so they don't masquerade as playable.
+  const streams = channel.streams.filter((s) => !!s.url)
   const hasStreams = streams.length > 0
 
   // Keep the media element's muted property in sync with React state (the `muted`
@@ -69,12 +70,14 @@ export function Player({ channel }: { channel: Channel }) {
     if (!video || !hasStreams) return
 
     const pageProtocol = typeof window !== 'undefined' ? window.location.protocol : 'https:'
-    const online = typeof navigator !== 'undefined' ? navigator.onLine : true
+    // Read connectivity fresh at classification time, not once — it can change mid-failover.
+    const isOnline = () => (typeof navigator !== 'undefined' ? navigator.onLine : true)
     const candidates = buildCandidates(streams, pageProtocol)
     const attempts: FailureClass[] = []
 
     let idx = 0
     let attemptId = 0 // guards stale async (dynamic import) resolutions
+    let nativeAttemptId = -1 // which attempt (if any) is the live native-HLS one
     let settled = false // whether the current attempt has resolved (success or failover)
     let hls: HlsInstance | undefined
     let deadline: ReturnType<typeof setTimeout> | undefined
@@ -157,6 +160,7 @@ export function Player({ channel }: { channel: Channel }) {
 
       // Native HLS (Safari): hand the URL straight to the media element.
       if (video.canPlayType('application/vnd.apple.mpegurl')) {
+        nativeAttemptId = myId
         video.src = c.url
         tryPlayMuted()
         armDeadline()
@@ -183,7 +187,7 @@ export function Player({ channel }: { channel: Channel }) {
               classifyFailure(
                 { scheme: c.scheme, responseCode: data.response?.code, details: data.details, fatalType: data.type },
                 pageProtocol,
-                online,
+                isOnline(),
               ),
             )
           })
@@ -196,15 +200,19 @@ export function Player({ channel }: { channel: Channel }) {
         })
     }
 
-    // First playable signal from the media element = success (true for both the
-    // hls.js and native paths; survives autoplay being blocked, since metadata
-    // loads regardless of whether playback was allowed to start audibly).
+    // Success = the media element can actually start playback (`canplay`) or is
+    // playing. We deliberately do NOT settle on `loadedmetadata`: metadata can
+    // parse while the media segments are dead/geo-blocked, and settling there
+    // would swallow the subsequent fatal error and freeze on a black player.
+    // `canplay` fires after decodable data arrives, even if autoplay is blocked.
     // Native-path error (the hls.js path classifies via its own ERROR event).
+    // Guarded by nativeAttemptId so a torn-down attempt's spurious `error`
+    // (from video.load()) can't fail over the next candidate prematurely.
     const onNativeError = () => {
-      if (hls) return
-      fail(classifyFailure({ scheme: candidates[idx]?.scheme ?? 'https' }, pageProtocol, online))
+      if (hls || nativeAttemptId !== attemptId) return
+      fail(classifyFailure({ scheme: candidates[idx]?.scheme ?? 'https' }, pageProtocol, isOnline()))
     }
-    video.addEventListener('loadedmetadata', markPlaying)
+    video.addEventListener('canplay', markPlaying)
     video.addEventListener('playing', markPlaying)
     video.addEventListener('error', onNativeError)
 
@@ -213,7 +221,7 @@ export function Player({ channel }: { channel: Channel }) {
     return () => {
       cancelled = true
       clearDeadline()
-      video.removeEventListener('loadedmetadata', markPlaying)
+      video.removeEventListener('canplay', markPlaying)
       video.removeEventListener('playing', markPlaying)
       video.removeEventListener('error', onNativeError)
       teardownHls()

--- a/app/src/components/Player.tsx
+++ b/app/src/components/Player.tsx
@@ -1,56 +1,260 @@
 import { useEffect, useRef, useState } from 'react'
 import type { Channel } from '../data/types'
+import { buildCandidates, classifyFailure, dominantClass, messageFor } from '../lib/playback'
+import type { FailureClass } from '../lib/playback'
 
-// U7 — basic hls.js player. Plays the first (playability-ordered) stream URL.
-// Browser-only: hls attaches in an effect, so SSR just renders the <video> shell.
-// Full multi-URL failover + failure classification is the separate player feature;
-// here we show an honest message on error instead of a silent black screen.
+// Full-playback player (pure linker — never proxies bytes). Walks the channel's
+// ordered stream URLs, failing over silently on fatal hls.js errors, and when
+// nothing plays shows one honest failure card (R4/R7) with a retry. Mixed-content
+// (http: on our https: page) is classified pre-flight and never attempted (R5).
+//
+// Classification lives in ../lib/playback (pure, tested there); this component is
+// the imperative hls.js adapter + state machine.
+
+// Aggressive load policies: hls.js defaults wait ~40-60s on a dead manifest, far
+// too patient for channel-zapping. We want fast failover to the next URL.
+const FAST_RETRY = { maxNumRetry: 1, retryDelayMs: 0, maxRetryDelayMs: 0 }
+const HLS_CONFIG = {
+  enableWorker: true,
+  manifestLoadPolicy: {
+    default: { maxTimeToFirstByteMs: 4000, maxLoadTimeMs: 8000, timeoutRetry: FAST_RETRY, errorRetry: { maxNumRetry: 0, retryDelayMs: 1000, maxRetryDelayMs: 4000 } },
+  },
+  playlistLoadPolicy: {
+    default: { maxTimeToFirstByteMs: 4000, maxLoadTimeMs: 8000, timeoutRetry: FAST_RETRY, errorRetry: { maxNumRetry: 1, retryDelayMs: 1000, maxRetryDelayMs: 4000 } },
+  },
+  fragLoadPolicy: {
+    default: { maxTimeToFirstByteMs: 6000, maxLoadTimeMs: 15000, timeoutRetry: FAST_RETRY, errorRetry: { maxNumRetry: 2, retryDelayMs: 1000, maxRetryDelayMs: 4000 } },
+  },
+}
+
+// Component-owned wall-clock deadline per URL: catches "connects but never
+// renders a frame" cases the load policies handle too slowly. Cleared the moment
+// the media element signals it has playable content.
+const DEADLINE_MS = 12_000
+
+// Minimal shape of the bits of an hls.js instance we drive (avoids static import).
+interface HlsInstance {
+  on(event: string, cb: (e: unknown, data: HlsErrorData) => void): void
+  loadSource(url: string): void
+  attachMedia(video: HTMLMediaElement): void
+  stopLoad(): void
+  detachMedia(): void
+  destroy(): void
+}
+interface HlsErrorData {
+  fatal: boolean
+  type?: string
+  details?: string
+  response?: { code?: number }
+}
+
 export function Player({ channel }: { channel: Channel }) {
   const videoRef = useRef<HTMLVideoElement>(null)
-  const [failed, setFailed] = useState(false)
-  const src = channel.streams[0]?.url
+  const [status, setStatus] = useState<'loading' | 'playing' | 'failed'>('loading')
+  const [failureClass, setFailureClass] = useState<FailureClass>('dead')
+  const [muted, setMuted] = useState(true)
+  const [retryToken, setRetryToken] = useState(0)
+
+  const streams = channel.streams
+  const hasStreams = streams.length > 0
+
+  // Keep the media element's muted property in sync with React state (the `muted`
+  // attribute is not reliably reflected by React, so drive it via the ref).
+  useEffect(() => {
+    if (videoRef.current) videoRef.current.muted = muted
+  }, [muted])
 
   useEffect(() => {
     const video = videoRef.current
-    if (!video || !src) return
-    let hls: { destroy(): void } | undefined
+    if (!video || !hasStreams) return
+
+    const pageProtocol = typeof window !== 'undefined' ? window.location.protocol : 'https:'
+    const online = typeof navigator !== 'undefined' ? navigator.onLine : true
+    const candidates = buildCandidates(streams, pageProtocol)
+    const attempts: FailureClass[] = []
+
+    let idx = 0
+    let attemptId = 0 // guards stale async (dynamic import) resolutions
+    let settled = false // whether the current attempt has resolved (success or failover)
+    let hls: HlsInstance | undefined
+    let deadline: ReturnType<typeof setTimeout> | undefined
     let cancelled = false
 
-    // Native HLS (Safari) first; otherwise dynamically import hls.js (client-only).
-    if (video.canPlayType('application/vnd.apple.mpegurl')) {
-      video.src = src
-    } else {
-      import('hls.js').then(({ default: Hls }) => {
-        if (cancelled) return
-        if (Hls.isSupported()) {
-          const instance = new Hls({ enableWorker: true })
-          hls = instance
-          instance.on(Hls.Events.ERROR, (_e, data) => {
-            if (data.fatal) setFailed(true)
-          })
-          instance.loadSource(src)
-          instance.attachMedia(video)
-        } else {
-          setFailed(true)
-        }
-      }).catch(() => setFailed(true))
+    setStatus('loading')
+    setMuted(true)
+
+    const clearDeadline = () => {
+      if (deadline) clearTimeout(deadline)
+      deadline = undefined
     }
+    const teardownHls = () => {
+      if (hls) {
+        try {
+          hls.stopLoad()
+          hls.detachMedia()
+          hls.destroy()
+        } catch {
+          /* hls teardown is best-effort */
+        }
+        hls = undefined
+      }
+      try {
+        video.removeAttribute('src')
+        video.load() // flush the media element (may fire a spurious 'error' — guarded by `settled`)
+      } catch {
+        /* ignore */
+      }
+    }
+    const tryPlayMuted = () => {
+      video.muted = true
+      const p = video.play()
+      if (p && typeof p.catch === 'function') p.catch(() => {}) // autoplay may be blocked; stay muted
+    }
+
+    // Move on to the next candidate (or fail honestly when exhausted).
+    const advance = () => {
+      clearDeadline()
+      teardownHls()
+      idx += 1
+      if (cancelled) return
+      if (idx < candidates.length) {
+        attempt()
+      } else {
+        setFailureClass(dominantClass(attempts))
+        setStatus('failed')
+      }
+    }
+    // The current attempt produced a usable stream — stop here (terminal success).
+    const markPlaying = () => {
+      if (settled || cancelled) return
+      settled = true
+      clearDeadline()
+      setStatus('playing')
+    }
+    // The current attempt failed — record the class and fail over.
+    const fail = (cls: FailureClass) => {
+      if (settled || cancelled) return
+      settled = true
+      attempts.push(cls)
+      advance()
+    }
+
+    const attempt = () => {
+      settled = false
+      attemptId += 1
+      const myId = attemptId
+      const c = candidates[idx]
+
+      // Known-unplayable before any network: don't even construct hls (R5).
+      if (c.preflightClass) {
+        fail(c.preflightClass)
+        return
+      }
+
+      // Native HLS (Safari): hand the URL straight to the media element.
+      if (video.canPlayType('application/vnd.apple.mpegurl')) {
+        video.src = c.url
+        tryPlayMuted()
+        deadline = setTimeout(() => fail('dead'), DEADLINE_MS)
+        return
+      }
+
+      // Everyone else: hls.js over MSE (client-only dynamic import).
+      import('hls.js')
+        .then(({ default: Hls }) => {
+          if (cancelled || myId !== attemptId) return
+          if (!Hls.isSupported()) {
+            fail('dead')
+            return
+          }
+          const instance = new Hls(HLS_CONFIG) as unknown as HlsInstance
+          hls = instance
+          instance.on(Hls.Events.MANIFEST_PARSED, () => {
+            if (cancelled || myId !== attemptId) return
+            tryPlayMuted()
+          })
+          instance.on(Hls.Events.ERROR, (_e, data) => {
+            if (cancelled || myId !== attemptId || !data?.fatal) return
+            fail(
+              classifyFailure(
+                { scheme: c.scheme, responseCode: data.response?.code, details: data.details, fatalType: data.type },
+                pageProtocol,
+                online,
+              ),
+            )
+          })
+          instance.loadSource(c.url)
+          instance.attachMedia(video)
+          deadline = setTimeout(() => fail('dead'), DEADLINE_MS)
+        })
+        .catch(() => {
+          if (!cancelled && myId === attemptId) fail('dead')
+        })
+    }
+
+    // First playable signal from the media element = success (true for both the
+    // hls.js and native paths; survives autoplay being blocked, since metadata
+    // loads regardless of whether playback was allowed to start audibly).
+    const onPlayable = () => markPlaying()
+    // Native-path error (the hls.js path classifies via its own ERROR event).
+    const onNativeError = () => {
+      if (hls) return
+      fail(classifyFailure({ scheme: candidates[idx]?.scheme ?? 'https' }, pageProtocol, online))
+    }
+    video.addEventListener('loadedmetadata', onPlayable)
+    video.addEventListener('playing', onPlayable)
+    video.addEventListener('error', onNativeError)
+
+    attempt()
+
     return () => {
       cancelled = true
-      hls?.destroy()
+      clearDeadline()
+      video.removeEventListener('loadedmetadata', onPlayable)
+      video.removeEventListener('playing', onPlayable)
+      video.removeEventListener('error', onNativeError)
+      teardownHls()
     }
-  }, [src])
+  }, [channel.id, retryToken, hasStreams, streams])
 
-  if (!src) return <p className="rounded bg-gray-100 p-4 text-sm text-gray-600">No stream available for this channel.</p>
+  if (!hasStreams) {
+    return <p className="rounded bg-gray-100 p-4 text-sm text-gray-600">No stream available for this channel.</p>
+  }
+
+  if (status === 'failed') {
+    return (
+      <div className="overflow-hidden rounded-lg bg-gray-900 p-4 text-sm text-gray-200" data-testid="player">
+        <p role="status" data-testid="player-error">
+          {messageFor(failureClass)}
+        </p>
+        <button
+          type="button"
+          onClick={() => {
+            setStatus('loading') // remount the <video> so the effect's ref is live again
+            setRetryToken((t) => t + 1)
+          }}
+          data-testid="player-retry"
+          className="mt-3 rounded bg-gray-700 px-3 py-1 text-white hover:bg-gray-600 focus:outline focus:outline-2 focus:outline-blue-400"
+        >
+          Try again
+        </button>
+      </div>
+    )
+  }
 
   return (
-    <div className="overflow-hidden rounded-lg bg-black" data-testid="player">
-      {failed && (
-        <p role="status" className="bg-gray-900 p-4 text-sm text-gray-300" data-testid="player-error">
-          This stream can’t be played in your browser — it may be offline or region-restricted.
-        </p>
+    <div className="relative overflow-hidden rounded-lg bg-black" data-testid="player">
+      <video ref={videoRef} controls playsInline autoPlay muted className="aspect-video w-full" />
+      {status === 'playing' && muted && (
+        <button
+          type="button"
+          onClick={() => setMuted(false)}
+          data-testid="player-unmute"
+          className="absolute bottom-3 right-3 rounded bg-black/70 px-3 py-1 text-sm text-white hover:bg-black/90 focus:outline focus:outline-2 focus:outline-blue-400"
+        >
+          Unmute
+        </button>
       )}
-      <video ref={videoRef} controls playsInline className="aspect-video w-full" />
     </div>
   )
 }

--- a/app/src/data/status.ts
+++ b/app/src/data/status.ts
@@ -1,0 +1,11 @@
+// Single source of truth for interpreting a stream's `status` (an untyped string
+// from the pipeline). Both the channel-card green dot and the channel-page
+// liveness hint render the same judgement — "is this stream plausibly live
+// enough to show a positive hint?" — so they share one predicate rather than
+// each owning a copy of the dead-status set (which would silently drift).
+const DEAD = new Set(['error', 'timeout', 'blocked', 'offline'])
+
+/** True when `status` is a known, not-dead, not-unknown value safe to surface as a positive liveness hint. */
+export function isPlausiblyLive(status: string | undefined): boolean {
+  return !!status && status !== 'unknown' && !DEAD.has(status)
+}

--- a/app/src/data/status.ts
+++ b/app/src/data/status.ts
@@ -1,8 +1,12 @@
-// Single source of truth for interpreting a stream's `status` (an untyped string
-// from the pipeline). Both the channel-card green dot and the channel-page
-// liveness hint render the same judgement — "is this stream plausibly live
-// enough to show a positive hint?" — so they share one predicate rather than
-// each owning a copy of the dead-status set (which would silently drift).
+// Single source of truth (app side) for interpreting a stream's `status` (an
+// untyped string from the pipeline). Both the channel-card green dot and the
+// channel-page liveness hint render the same judgement — "is this stream
+// plausibly live enough to show a positive hint?" — so they share one predicate.
+//
+// NOTE: this set mirrors the pipeline's authoritative DEAD_STATUS in
+// pipeline/src/schema.js. The app and pipeline are separate bundles (the app
+// must not import Node pipeline code into the edge build), so the values are
+// duplicated by necessity; keep them in sync if the pipeline's set changes.
 const DEAD = new Set(['error', 'timeout', 'blocked', 'offline'])
 
 /** True when `status` is a known, not-dead, not-unknown value safe to surface as a positive liveness hint. */

--- a/app/src/lib/liveness.test.ts
+++ b/app/src/lib/liveness.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { livenessHint } from './liveness'
+import type { Stream } from '../data/types'
+
+const NOW = new Date('2026-06-29T12:00:00Z')
+
+function stream(checkedAt: string | null, status = 'online'): Stream {
+  return { url: 'https://x/y.m3u8', status, checkedAt, scheme: 'https', likelyPlayable: true, quality: null }
+}
+
+describe('livenessHint', () => {
+  it('renders an informative hint for a stream checked hours ago', () => {
+    const hint = livenessHint(stream('2026-06-29T08:00:00Z'), NOW)
+    expect(hint?.text).toMatch(/4h/)
+    expect(hint?.text).toMatch(/ago/)
+  })
+
+  it('renders a day-scale hint (and never "LIVE") for a 30-hours-stale check', () => {
+    const hint = livenessHint(stream('2026-06-28T06:00:00Z'), NOW)
+    expect(hint?.text).toBe('checked 1d ago')
+    expect(hint?.text).not.toMatch(/LIVE/i)
+  })
+
+  it('says "just now" under a minute and "Nm ago" for a few minutes', () => {
+    expect(livenessHint(stream('2026-06-29T11:59:30Z'), NOW)?.text).toBe('checked just now')
+    expect(livenessHint(stream('2026-06-29T11:45:00Z'), NOW)?.text).toBe('checked 15m ago')
+  })
+
+  it('suppresses the hint for dead statuses', () => {
+    for (const status of ['timeout', 'offline', 'error', 'blocked']) {
+      expect(livenessHint(stream('2026-06-29T11:00:00Z', status), NOW)).toBeNull()
+    }
+  })
+
+  it('suppresses the hint when checkedAt is missing or status is unknown', () => {
+    expect(livenessHint(stream(null), NOW)).toBeNull()
+    expect(livenessHint(stream('2026-06-29T11:00:00Z', 'unknown'), NOW)).toBeNull()
+  })
+
+  it('returns null for an undefined stream', () => {
+    expect(livenessHint(undefined, NOW)).toBeNull()
+  })
+})

--- a/app/src/lib/liveness.ts
+++ b/app/src/lib/liveness.ts
@@ -1,0 +1,34 @@
+import type { Stream } from '../data/types'
+
+// Best-effort, time-stamped liveness hint for the channel page (R8). The pipeline
+// is daily, so `checkedAt` can be up to a day stale — this is framed as a hint,
+// never as a "LIVE" guarantee, and is suppressed entirely for unknown/dead
+// statuses so it can never read as a false positive.
+
+// Mirror ChannelCard's dead-status set (no false hint for known-down streams).
+const DEAD = new Set(['error', 'timeout', 'blocked', 'offline'])
+
+/**
+ * Relative, plain-language liveness hint, or null when no honest hint can be shown.
+ * Pure: `now` is passed in so the result is deterministic and testable.
+ */
+export function livenessHint(stream: Stream | undefined, now: Date): { text: string } | null {
+  if (!stream || !stream.status || stream.status === 'unknown' || DEAD.has(stream.status)) return null
+  if (!stream.checkedAt) return null
+
+  const checked = new Date(stream.checkedAt).getTime()
+  if (Number.isNaN(checked)) return null
+
+  const diffMs = now.getTime() - checked
+  if (diffMs < 0) return { text: 'checked just now' } // clock skew — don't show a future time
+
+  const minutes = Math.floor(diffMs / 60_000)
+  if (minutes < 1) return { text: 'checked just now' }
+  if (minutes < 60) return { text: `checked ${minutes}m ago` }
+
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return { text: `checked ${hours}h ago` }
+
+  const days = Math.floor(hours / 24)
+  return { text: `checked ${days}d ago` }
+}

--- a/app/src/lib/liveness.ts
+++ b/app/src/lib/liveness.ts
@@ -18,8 +18,8 @@ export function livenessHint(stream: Stream | undefined, now: Date): { text: str
   if (Number.isNaN(checked)) return null
 
   const diffMs = now.getTime() - checked
-  if (diffMs < 0) return { text: 'checked just now' } // clock skew — don't show a future time
-
+  // A negative diff (clock skew) floors to negative minutes, which the `< 1`
+  // branch below renders as "just now" — no separate guard needed.
   const minutes = Math.floor(diffMs / 60_000)
   if (minutes < 1) return { text: 'checked just now' }
   if (minutes < 60) return { text: `checked ${minutes}m ago` }

--- a/app/src/lib/liveness.ts
+++ b/app/src/lib/liveness.ts
@@ -1,19 +1,17 @@
 import type { Stream } from '../data/types'
+import { isPlausiblyLive } from '../data/status'
 
 // Best-effort, time-stamped liveness hint for the channel page (R8). The pipeline
 // is daily, so `checkedAt` can be up to a day stale — this is framed as a hint,
 // never as a "LIVE" guarantee, and is suppressed entirely for unknown/dead
 // statuses so it can never read as a false positive.
 
-// Mirror ChannelCard's dead-status set (no false hint for known-down streams).
-const DEAD = new Set(['error', 'timeout', 'blocked', 'offline'])
-
 /**
  * Relative, plain-language liveness hint, or null when no honest hint can be shown.
  * Pure: `now` is passed in so the result is deterministic and testable.
  */
 export function livenessHint(stream: Stream | undefined, now: Date): { text: string } | null {
-  if (!stream || !stream.status || stream.status === 'unknown' || DEAD.has(stream.status)) return null
+  if (!stream || !isPlausiblyLive(stream.status)) return null
   if (!stream.checkedAt) return null
 
   const checked = new Date(stream.checkedAt).getTime()

--- a/app/src/lib/playback.test.ts
+++ b/app/src/lib/playback.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { buildCandidates, classifyFailure, dominantClass, messageFor } from './playback'
+import type { FailureClass } from './playback'
+import type { Stream } from '../data/types'
+
+function stream(url: string, overrides: Partial<Stream> = {}): Stream {
+  const scheme = url.startsWith('https') ? 'https' : 'http'
+  return { url, status: 'online', checkedAt: null, scheme, likelyPlayable: true, quality: null, ...overrides }
+}
+
+describe('buildCandidates', () => {
+  it('preserves snapshot order and marks only http-on-https as browser-blocked', () => {
+    const candidates = buildCandidates(
+      [stream('https://a/1.m3u8'), stream('http://b/2.m3u8'), stream('https://c/3.m3u8')],
+      'https:',
+    )
+    expect(candidates.map((c) => c.url)).toEqual(['https://a/1.m3u8', 'http://b/2.m3u8', 'https://c/3.m3u8'])
+    expect(candidates[0].preflightClass).toBeUndefined()
+    expect(candidates[1].preflightClass).toBe('browser-blocked')
+    expect(candidates[2].preflightClass).toBeUndefined()
+  })
+
+  it('does not pre-mark http streams on an http page (dev)', () => {
+    const candidates = buildCandidates([stream('http://b/2.m3u8')], 'http:')
+    expect(candidates[0].preflightClass).toBeUndefined()
+  })
+
+  it('returns [] for no streams', () => {
+    expect(buildCandidates([], 'https:')).toEqual([])
+  })
+
+  it('returns a single candidate with no preflightClass for one https stream', () => {
+    const candidates = buildCandidates([stream('https://a/1.m3u8')], 'https:')
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0].preflightClass).toBeUndefined()
+  })
+})
+
+describe('classifyFailure', () => {
+  it('classifies http-on-https as browser-blocked (mixed content)', () => {
+    expect(classifyFailure({ scheme: 'http' }, 'https:', true)).toBe('browser-blocked')
+  })
+
+  it('classifies 403 and 451 as region-restricted', () => {
+    expect(classifyFailure({ scheme: 'https', responseCode: 403 }, 'https:', true)).toBe('region-restricted')
+    expect(classifyFailure({ scheme: 'https', responseCode: 451 }, 'https:', true)).toBe('region-restricted')
+  })
+
+  it('classifies 404, 410 and 5xx as dead', () => {
+    for (const code of [404, 410, 500, 503]) {
+      expect(classifyFailure({ scheme: 'https', responseCode: code }, 'https:', true)).toBe('dead')
+    }
+  })
+
+  it('classifies a status-less failure while offline as dead (do not blame the channel)', () => {
+    const cls = classifyFailure({ scheme: 'https', responseCode: 0 }, 'https:', false)
+    expect(cls).toBe('dead')
+  })
+
+  it('classifies a status-less failure while online as browser-blocked, with conservative copy', () => {
+    const cls = classifyFailure({ scheme: 'https', responseCode: 0 }, 'https:', true)
+    expect(cls).toBe('browser-blocked')
+    const msg = messageFor(cls)
+    expect(msg).not.toMatch(/region/i)
+    expect(msg).not.toMatch(/CORS/i)
+  })
+
+  it('classifies timeout / parse / codec / media failures (no code) as dead', () => {
+    expect(classifyFailure({ scheme: 'https', details: 'manifestLoadTimeOut' }, 'https:', true)).toBe('dead')
+    expect(classifyFailure({ scheme: 'https', details: 'manifestParsingError' }, 'https:', true)).toBe('dead')
+    expect(classifyFailure({ scheme: 'https', details: 'manifestIncompatibleCodecsError' }, 'https:', true)).toBe('dead')
+    expect(classifyFailure({ scheme: 'https', fatalType: 'mediaError' }, 'https:', true)).toBe('dead')
+  })
+})
+
+describe('dominantClass', () => {
+  it('prefers region-restricted over dead over browser-blocked', () => {
+    expect(dominantClass(['browser-blocked', 'region-restricted', 'dead'])).toBe('region-restricted')
+    expect(dominantClass(['browser-blocked', 'dead'])).toBe('dead')
+    expect(dominantClass(['browser-blocked'])).toBe('browser-blocked')
+  })
+
+  it('returns a safe default (dead) for no attempts', () => {
+    expect(dominantClass([])).toBe('dead')
+  })
+})
+
+describe('messageFor', () => {
+  it('returns a non-empty string for every failure class', () => {
+    const classes: FailureClass[] = ['dead', 'browser-blocked', 'region-restricted']
+    for (const c of classes) {
+      expect(messageFor(c).length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/app/src/lib/playback.ts
+++ b/app/src/lib/playback.ts
@@ -1,0 +1,128 @@
+// Pure playback failure-classification + candidate-building. No DOM, no hls.js
+// import — the Player component adapts hls.js error events into the small
+// `FailureInput` descriptor below and calls in here. Keeping this isolated
+// makes the branchy R7 logic unit-testable, and gives the future analytics
+// feature a stable machine-readable `FailureClass` to consume.
+import type { Stream } from '../data/types'
+
+export type FailureClass = 'dead' | 'browser-blocked' | 'region-restricted'
+
+/** A stream URL to attempt, in snapshot order. */
+export interface Candidate {
+  url: string
+  scheme: Stream['scheme']
+  /** Set when the candidate is known-unplayable before hls.js is even tried
+   *  (http: on an https: page = mixed content). Such candidates are still
+   *  listed (R5/R9: surface, don't hide) but classified without a network hit. */
+  preflightClass?: FailureClass
+}
+
+/** Minimal, hls.js-decoupled descriptor of a fatal playback failure. */
+export interface FailureInput {
+  /** URL scheme of the attempted stream. */
+  scheme: Stream['scheme']
+  /** HTTP status from hls.js `data.response.code`, when the origin returned
+   *  CORS-permissive headers. `0` or undefined means no usable status (CORS /
+   *  DNS / dead host / header-less 4xx all collapse here — indistinguishable). */
+  responseCode?: number
+  /** hls.js `data.details` (e.g. 'manifestLoadTimeOut', 'manifestParsingError'). */
+  details?: string
+  /** hls.js `data.type` (e.g. 'networkError', 'mediaError'). */
+  fatalType?: string
+}
+
+const MESSAGES: Record<FailureClass, string> = {
+  dead: 'This stream appears to be offline or unavailable right now.',
+  'browser-blocked':
+    "This stream can’t be played in your browser — it’s blocked or unreachable from this page.",
+  'region-restricted': 'This stream may be region-restricted in your area.',
+}
+
+/** Plain-language copy for a failure class. Intentionally conservative: the
+ *  browser-blocked message never asserts a specific cause (CORS vs DNS vs a
+ *  header-less 403 are not distinguishable in the browser). */
+export function messageFor(failure: FailureClass): string {
+  return MESSAGES[failure]
+}
+
+/**
+ * Build the ordered candidate list from a channel's snapshot streams.
+ * Order is preserved (the pipeline supplies HTTPS-preferred ordering, R6/R18).
+ * Nothing is dropped — http-on-https is marked browser-blocked up front (R5).
+ */
+export function buildCandidates(streams: Stream[], pageProtocol: string): Candidate[] {
+  const httpsPage = pageProtocol === 'https:'
+  return streams.map((s) => {
+    const candidate: Candidate = { url: s.url, scheme: s.scheme }
+    if (httpsPage && s.scheme === 'http') candidate.preflightClass = 'browser-blocked'
+    return candidate
+  })
+}
+
+/**
+ * Classify a fatal stream failure into one user-facing class (R7).
+ *
+ * Decision order (from the hls.js v1.6.16 error-model research):
+ *  1. Mixed content — http: on an https: page. Reliable, no network needed.
+ *  2. A real HTTP status (origin was CORS-permissive):
+ *       403 / 451 → region-restricted; 404 / 410 / 5xx → dead.
+ *  3. No usable status AND the viewer is offline → dead (don't blame the channel).
+ *  4. No usable status AND online → browser-blocked (best-effort; this bucket
+ *       unavoidably also holds DNS-dead hosts and header-less 4xx).
+ *  5. Timeouts / parse / incompatible-codec / media failures → dead.
+ */
+export function classifyFailure(input: FailureInput, pageProtocol: string, online: boolean): FailureClass {
+  // 1. Mixed content — decidable from the scheme alone.
+  if (pageProtocol === 'https:' && input.scheme === 'http') return 'browser-blocked'
+
+  // 2. A real, CORS-visible HTTP status.
+  const code = input.responseCode
+  if (typeof code === 'number' && code > 0) {
+    if (code === 403 || code === 451) return 'region-restricted'
+    if (code === 404 || code === 410) return 'dead'
+    if (code >= 500 && code <= 599) return 'dead'
+    // Any other explicit status: treat as dead (unusable), not a geo claim.
+    return 'dead'
+  }
+
+  // 3. No usable status, viewer offline — their connection, not the channel.
+  if (!online) return 'dead'
+
+  // 4. No usable status, online — most likely CORS/mixed/unreachable. Best-effort.
+  //    Timeouts and content errors still carry a status-less signal but read as
+  //    "dead/unavailable" rather than "blocked"; separate them out first.
+  const d = (input.details ?? '').toLowerCase()
+  const isContentOrTimeout =
+    d.includes('timeout') ||
+    d.includes('parsing') ||
+    d.includes('parse') ||
+    d.includes('codec') ||
+    d.includes('buffer') ||
+    d.includes('mux') ||
+    input.fatalType === 'mediaError'
+  if (isContentOrTimeout) return 'dead'
+
+  // 5. A bare network failure with no status while online: blocked or unreachable.
+  return 'browser-blocked'
+}
+
+// More-informative classes win: a confirmed geo-gate (403/451) is more
+// actionable than a bare network failure, so it should dominate the final card.
+const INFORMATIVENESS: Record<FailureClass, number> = {
+  'region-restricted': 3,
+  dead: 2,
+  'browser-blocked': 1,
+}
+
+/** Pick the dominant failure class across all attempted URLs (origin F2). */
+export function dominantClass(classes: FailureClass[]): FailureClass {
+  let best: FailureClass = 'dead' // safe default so the UI never renders empty copy
+  let bestScore = -1
+  for (const c of classes) {
+    if (INFORMATIVENESS[c] > bestScore) {
+      best = c
+      bestScore = INFORMATIVENESS[c]
+    }
+  }
+  return best
+}

--- a/app/src/lib/playback.ts
+++ b/app/src/lib/playback.ts
@@ -75,13 +75,11 @@ export function classifyFailure(input: FailureInput, pageProtocol: string, onlin
   // 1. Mixed content — decidable from the scheme alone.
   if (pageProtocol === 'https:' && input.scheme === 'http') return 'browser-blocked'
 
-  // 2. A real, CORS-visible HTTP status.
+  // 2. A real, CORS-visible HTTP status. 403/451 read as a geo gate; any other
+  //    explicit status (404/410/5xx/etc.) is an unusable stream, not a geo claim.
   const code = input.responseCode
   if (typeof code === 'number' && code > 0) {
     if (code === 403 || code === 451) return 'region-restricted'
-    if (code === 404 || code === 410) return 'dead'
-    if (code >= 500 && code <= 599) return 'dead'
-    // Any other explicit status: treat as dead (unusable), not a geo claim.
     return 'dead'
   }
 
@@ -91,6 +89,10 @@ export function classifyFailure(input: FailureInput, pageProtocol: string, onlin
   // 4. No usable status, online — most likely CORS/mixed/unreachable. Best-effort.
   //    Timeouts and content errors still carry a status-less signal but read as
   //    "dead/unavailable" rather than "blocked"; separate them out first.
+  //    `details` is treated as an opaque lowercased string (deliberately no
+  //    hls.js import). `timeout`/`parsing` are the network-error signals; the
+  //    media substrings (codec/buffer/mux) are a version-drift hedge that mostly
+  //    overlaps the `mediaError` type check beside them.
   const d = (input.details ?? '').toLowerCase()
   const isContentOrTimeout =
     d.includes('timeout') ||

--- a/app/src/routes/channel.$id.tsx
+++ b/app/src/routes/channel.$id.tsx
@@ -3,7 +3,7 @@ import { getStore } from '../data/store'
 import { getChannel } from '../data/kv'
 import { Player } from '../components/Player'
 import { StructuredData } from '../components/StructuredData'
-import { livenessHint } from '../lib/liveness'
+import { LivenessHint } from '../components/LivenessHint'
 
 export const Route = createFileRoute('/channel/$id')({
   loader: async ({ params }) => {
@@ -25,7 +25,6 @@ export const Route = createFileRoute('/channel/$id')({
 
 function ChannelPage() {
   const { channel } = Route.useLoaderData()
-  const liveness = livenessHint(channel.streams[0], new Date())
   const videoObject = {
     '@context': 'https://schema.org',
     '@type': 'VideoObject',
@@ -54,7 +53,7 @@ function ChannelPage() {
         {channel.logo && <img src={channel.logo} alt="" className="h-12 w-12 rounded object-contain" />}
         <div className="text-sm text-gray-600">
           <p>{[channel.country?.toUpperCase(), ...channel.categories].filter(Boolean).join(' · ')}</p>
-          {liveness && <p className="text-xs text-gray-400" title="best-effort — streams are checked about daily">{liveness.text}</p>}
+          <LivenessHint stream={channel.streams[0]} />
         </div>
       </section>
       {channel.categories[0] && (

--- a/app/src/routes/channel.$id.tsx
+++ b/app/src/routes/channel.$id.tsx
@@ -3,6 +3,7 @@ import { getStore } from '../data/store'
 import { getChannel } from '../data/kv'
 import { Player } from '../components/Player'
 import { StructuredData } from '../components/StructuredData'
+import { livenessHint } from '../lib/liveness'
 
 export const Route = createFileRoute('/channel/$id')({
   loader: async ({ params }) => {
@@ -24,6 +25,7 @@ export const Route = createFileRoute('/channel/$id')({
 
 function ChannelPage() {
   const { channel } = Route.useLoaderData()
+  const liveness = livenessHint(channel.streams[0], new Date())
   const videoObject = {
     '@context': 'https://schema.org',
     '@type': 'VideoObject',
@@ -52,7 +54,7 @@ function ChannelPage() {
         {channel.logo && <img src={channel.logo} alt="" className="h-12 w-12 rounded object-contain" />}
         <div className="text-sm text-gray-600">
           <p>{[channel.country?.toUpperCase(), ...channel.categories].filter(Boolean).join(' · ')}</p>
-          {channel.streams[0]?.checkedAt && <p className="text-xs text-gray-400">checked {channel.streams[0].checkedAt.slice(0, 10)}</p>}
+          {liveness && <p className="text-xs text-gray-400" title="best-effort — streams are checked about daily">{liveness.text}</p>}
         </div>
       </section>
       {channel.categories[0] && (


### PR DESCRIPTION
## What & why

Extends the basic single-URL player into the full **v2 Player feature** (plan: `docs/plans/2026-06-29-003-feat-v2-player-plan.md`, requirements: `docs/brainstorms/2026-06-28-v2-player-requirements.md`). The player stays a **pure linker** — it never proxies or rewrites stream bytes (R5).

A dead/region-locked/browser-blocked stream used to yield a black player with one generic message. Now the player walks the channel's ordered stream URLs, fails over silently on fatal errors, and when nothing plays shows **one honest, plain-language failure card** naming the most likely cause, with a retry — never a silent black screen.

## How it works

- **`app/src/lib/playback.ts`** — pure, fully-unit-tested classifier (no DOM, no hls.js import). `buildCandidates` pre-flights `http:`-on-`https:` as browser-blocked (mixed content, reliable without a network hit); `classifyFailure` maps an hls.js fatal-error descriptor → `dead | browser-blocked | region-restricted`; `dominantClass` picks the most-informative cause across attempts. Mapping is grounded in the hls.js v1.6.16 error model (403/451 → region; 404/410/5xx → dead; status-less + online → browser-blocked, conservatively worded; `navigator.onLine === false` → offline-flavoured).
- **`app/src/components/Player.tsx`** — imperative failover state machine: a fresh `Hls()` per candidate with aggressive load policies (~4s TTFB / ~8s manifest) plus a 12s per-URL wall-clock deadline for stalls; **muted autoplay** with an Unmute affordance; success settles on `canplay`/`playing` (not `loadedmetadata`); clean teardown (`stopLoad → detachMedia → destroy` + media flush) on unmount, channel change, and retry.
- **`app/src/lib/liveness.ts` + `app/src/components/LivenessHint.tsx`** — best-effort, relative "checked Nh ago" hint (R8), suppressed for dead/unknown statuses so it never reads as a false "LIVE". Rendered client-only to avoid an SSR hydration mismatch.
- **`app/src/data/status.ts`** — shared `isPlausiblyLive` predicate, consumed by both `ChannelCard`'s green dot and the liveness hint (kills a duplicated dead-status set).

## Testing

- **47 app tests pass** (`cd app && npm run test`), including: classifier branch coverage, failover across URLs, mixed-content pre-flight, region-restricted messaging, exhaustion → single honest card + retry, retry re-attempt, unmount teardown, the `canplay`-not-`loadedmetadata` settle regression, and the empty-URL guard.
- **Browser-verified via Playwright MCP**: `/channel/$id` renders the honest-failure card (plain copy + Try again), the liveness hint, and full channel context; **zero console errors/warnings** (no hydration mismatch) and clean teardown on navigation.
- Type-clean (the one pre-existing `kv.test.ts` unused-import error is on `master`, unrelated).

## Review

Ran `/simplify` (4 angles) then a high-effort multi-agent `/code-review` (33 agents). **Fixed** the confirmed correctness bugs: premature settle on `loadedmetadata` (could swallow a later fatal segment error → black screen), empty-URL streams bypassing the no-stream guard, SSR `new Date()` hydration mismatch, once-sampled `navigator.onLine`, and a stale-attempt race in the native-error handler.

### Accepted by design (not bugs — documented)
- **Conservative region copy** — `region-restricted` only on a CORS-visible 403/451; status-less geo-blocks read as "blocked or unreachable". Deliberate per the honest-classification decision (the hls.js research warns `code: 0` can't be distinguished from CORS/DNS; over-claiming "region" would be dishonest).
- **Liveness suppressed for dead/unknown status** — matches R8 ("never a false LIVE"); the prior code showed a bare date with no liveness semantics.
- **Fresh `Hls()` per URL** (vs reuse) — hls.js guidance: avoids stale penalty-box/level state bleeding across unrelated URLs.
- **12s stall deadline classifies as `dead`** — tunable constant (plan defers tuning); a stall yields no error data, so "unavailable" is the honest call.
- **`DEAD` status duplicated app-side vs `pipeline/src/schema.js`** — app and pipeline are separate bundles (the edge build must not import Node pipeline code); duplication is by necessity, now flagged with a sync-pointer comment.

## Post-Deploy Monitoring & Validation

No server/runtime infra change — the player is client-side and adds **zero hosting bill** (pure linker, no proxy). Once the v2 app is live, the natural signal is the playback-failure rate by class, which the **analytics feature** (separate) will emit from `classifyFailure`'s machine-readable class. Until then: spot-check a few `/channel/$id` pages for working playback and an honest card on dead channels; watch the browser console for teardown/hydration errors. Rollback = revert this PR (no data/schema migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
