### PR TITLE
feat: v2 EPG pipeline — XMLTV → UTC schedule → KV (epg.pw + name matching)

### DIFF
--- a/.github/workflows/v2-epg.yml
+++ b/.github/workflows/v2-epg.yml
@@ -1,0 +1,37 @@
+name: v2 EPG refresh
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'   # every 6h — own cadence, independent of the daily catalog (origin R2)
+  workflow_dispatch:
+
+# Serialize EPG runs separately from the catalog pipeline so neither blocks the other.
+concurrency:
+  group: v2-epg
+  cancel-in-progress: false
+
+jobs:
+  epg:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # Zero-dependency (Node built-ins + global fetch) — no install step, like the
+      # catalog pipeline. EPG tests run under the shared test:pipeline glob.
+      - name: Run pipeline tests
+        run: npm run test:pipeline
+
+      - name: Run EPG job (guides + XMLTV → KV)
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CF_KV_NAMESPACE_ID: ${{ secrets.CF_KV_NAMESPACE_ID }}
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
+        run: node ./pipeline/src/epg/run.js

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eject": "react-scripts eject",
     "generatePlaylist": "node ./playlistGenerator.js",
     "pipeline": "node ./pipeline/src/run.js",
+    "epg": "node ./pipeline/src/epg/run.js",
     "test:pipeline": "node --test pipeline/test/*.test.js",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build"

--- a/pipeline/src/epg/build.js
+++ b/pipeline/src/epg/build.js
@@ -1,24 +1,36 @@
 'use strict';
 /**
- * U2 — EPG build: guides.json + XMLTV → mapped, windowed, per-country compact
- * schedules + per-scope coverage (origin R1, R3, R6, R7, R8).
+ * U2 — EPG build: per-country hosted XMLTV bundle → name-matched, windowed,
+ * compact per-country schedules + per-scope coverage (origin R1, R3, R6, R7, R8).
  *
- * Pure-ish: the XMLTV fetcher is injected so this is fully unit-testable with no
- * network. Deduplicates fetches by source URL, maps source channel ids back to
- * iptv-org channel ids (site_id or iptv id), and degrades silently where data
- * is missing (unmapped/scheduleless channels are simply absent — origin R7).
+ * Source reality (verified against live data during ce-work): iptv-org
+ * guides.json carries `site`+`site_id` pointers into diverse grabber sites but
+ * almost never a hosted `sources[].url` (2 of ~180k entries), so the only
+ * no-self-scrape path is epg.pw's per-region bundles. Those key programmes by
+ * epg.pw's own numeric channel ids with a `<display-name>`, and there is no
+ * guides.json bridge to epg.pw, so we map epg.pw channels to our catalog by
+ * normalized channel NAME within the same country (best-effort; ~40% of a
+ * well-covered country's catalog matches). Unmatched channels degrade silently
+ * (origin R7). guides.json `sources[].url` is a future precise-mapping upgrade.
+ *
+ * Pure-ish: the per-country XMLTV fetcher is injected, so fully unit-testable.
  */
-const { parseXmltv } = require('./xmltv');
+const { parseXmltv, parseXmltvChannels } = require('./xmltv');
 const { toStorageCountryCode } = require('../schema');
 
 const HOUR_MS = 3600 * 1000;
 const DEFAULT_BRACKET_HOURS = 36; // ±1 source-day, generous for far-offset viewers
 
-/** Prefer an XMLTV source url from a guide entry's sources[] (format XML first). */
-function guideSourceUrl(guide) {
-  const sources = Array.isArray(guide.sources) ? guide.sources : [];
-  const xml = sources.find((s) => s && s.url && /xml/i.test(s.format || '')) || sources.find((s) => s && s.url);
-  return xml ? xml.url : null;
+/**
+ * Normalize a channel name for cross-source matching: drop quality tokens
+ * (HD/SD/4K…), lowercase, strip everything non-alphanumeric.
+ * "Sky Witness HD" → "skywitness"; matches catalog "Sky Witness".
+ */
+function normalizeName(name) {
+  return String(name || '')
+    .toLowerCase()
+    .replace(/\b(hd|sd|fhd|uhd|4k|hevc|hq)\b/g, '')
+    .replace(/[^a-z0-9]/g, '');
 }
 
 /** Fill missing stops from the next programme's start; sort by start. */
@@ -49,86 +61,77 @@ function compact(p) {
 
 /**
  * @param {object} args
- * @param {Array<{id:string,country:string}>} args.channels   catalog channels (raw country ok)
- * @param {Array<object>} args.guides                          iptv-org guides.json entries
- * @param {string[]} args.coveredCountries                     storage country codes to process
- * @param {(url:string)=>Promise<string>} args.fetchText       XMLTV fetcher (injected)
- * @param {number} args.now                                    UTC ms reference for the window
+ * @param {Array<{id:string,name:string,country:string}>} args.channels  catalog channels
+ * @param {string[]} args.coveredCountries     storage country codes to process (e.g. ['gb','us'])
+ * @param {(code:string)=>Promise<string|null>} args.fetchBundle  per-country XMLTV fetcher (injected)
+ * @param {number} args.now                     UTC ms reference for the window
  * @param {number} [args.bracketHours]
  * @returns {Promise<{shardsByCountry:Object, coverage:Object}>}
  */
-async function buildEpg({ channels, guides, coveredCountries, fetchText, now, bracketHours = DEFAULT_BRACKET_HOURS }) {
-  const covered = new Set(coveredCountries);
+async function buildEpg({ channels, coveredCountries, fetchBundle, now, bracketHours = DEFAULT_BRACKET_HOURS }) {
   const bracketMs = bracketHours * HOUR_MS;
   const windowStart = now - bracketMs;
   const windowEnd = now + bracketMs;
 
-  // channel id → storage country, scoped to covered countries.
-  const countryOf = new Map();
-  const scopeCounts = new Map(); // country → total scope channels
+  // Catalog channels grouped by storage country, with a normalized-name lookup.
+  const scopeByCountry = new Map(); // code → { total, nameToId: Map }
   for (const ch of channels) {
     const code = toStorageCountryCode(ch.country);
-    if (!covered.has(code)) continue;
-    countryOf.set(ch.id, code);
-    scopeCounts.set(code, (scopeCounts.get(code) || 0) + 1);
+    if (!coveredCountries.includes(code)) continue;
+    if (!scopeByCountry.has(code)) scopeByCountry.set(code, { total: 0, nameToId: new Map() });
+    const scope = scopeByCountry.get(code);
+    scope.total++;
+    const key = normalizeName(ch.name);
+    if (key && !scope.nameToId.has(key)) scope.nameToId.set(key, ch.id); // first wins on collision
   }
 
-  // Group covered channels' guide entries by their (deduped) source URL.
-  // urlToEntries: url → [{ iptvId, siteId, lang }]
-  const urlToEntries = new Map();
-  for (const g of guides) {
-    if (!g.channel || !countryOf.has(g.channel)) continue;
-    const url = guideSourceUrl(g);
-    if (!url) continue;
-    if (!urlToEntries.has(url)) urlToEntries.set(url, []);
-    urlToEntries.get(url).push({ iptvId: g.channel, siteId: g.site_id, lang: g.lang });
-  }
+  const shardsByCountry = {};
+  const coverage = {};
 
-  // Accumulate programmes per iptv channel id.
-  const byChannel = new Map();
-  for (const [url, entries] of urlToEntries) {
-    let doc;
+  for (const code of coveredCountries) {
+    const scope = scopeByCountry.get(code) || { total: 0, nameToId: new Map() };
+    coverage[code] = 0;
+    if (scope.total === 0) continue;
+
+    let xml;
     try {
-      doc = await fetchText(url);
+      xml = await fetchBundle(code);
     } catch {
-      continue; // best-effort: one bad source must not sink the whole build
+      continue; // best-effort: one bad region must not sink the others
     }
-    // Build a source-channel-id → iptv-id lookup (try site_id and the iptv id itself).
-    const lookup = new Map();
-    for (const e of entries) {
-      if (e.siteId) lookup.set(e.siteId, e.iptvId);
-      lookup.set(e.iptvId, e.iptvId);
+    if (!xml) continue;
+
+    // epg.pw channel id → our iptv id, via normalized display-name.
+    const epgIdToIptv = new Map();
+    for (const c of parseXmltvChannels(xml)) {
+      const iptvId = scope.nameToId.get(normalizeName(c.name));
+      if (iptvId) epgIdToIptv.set(c.id, iptvId);
     }
-    const lang = entries[0] && entries[0].lang;
-    for (const prog of parseXmltv(doc, { lang })) {
-      const iptvId = lookup.get(prog.sourceChannelId);
-      if (!iptvId) continue; // unmapped → drop (silent, never wrong)
+
+    // Group programmes by iptv channel id.
+    const byChannel = new Map();
+    for (const prog of parseXmltv(xml)) {
+      const iptvId = epgIdToIptv.get(prog.sourceChannelId);
+      if (!iptvId) continue; // unmatched epg.pw channel → drop (silent)
       if (!byChannel.has(iptvId)) byChannel.set(iptvId, []);
       byChannel.get(iptvId).push(prog);
     }
-  }
 
-  // Window + compact + group by country.
-  const shardsByCountry = {};
-  const withSchedule = new Map(); // country → count of channels that got a schedule
-  for (const [iptvId, programmes] of byChannel) {
-    const country = countryOf.get(iptvId);
-    if (!country) continue;
-    const windowed = inWindow(fillStops(programmes), windowStart, windowEnd);
-    if (windowed.length === 0) continue;
-    if (!shardsByCountry[country]) shardsByCountry[country] = {};
-    shardsByCountry[country][iptvId] = windowed.map(compact);
-    withSchedule.set(country, (withSchedule.get(country) || 0) + 1);
-  }
+    // Window + compact.
+    const shard = {};
+    let withSchedule = 0;
+    for (const [iptvId, programmes] of byChannel) {
+      const windowed = inWindow(fillStops(programmes), windowStart, windowEnd);
+      if (windowed.length === 0) continue;
+      shard[iptvId] = windowed.map(compact);
+      withSchedule++;
+    }
 
-  // Coverage = channels-with-schedule / total-scope-channels, per covered country.
-  const coverage = {};
-  for (const code of covered) {
-    const total = scopeCounts.get(code) || 0;
-    coverage[code] = total > 0 ? (withSchedule.get(code) || 0) / total : 0;
+    if (withSchedule > 0) shardsByCountry[code] = shard;
+    coverage[code] = withSchedule / scope.total;
   }
 
   return { shardsByCountry, coverage };
 }
 
-module.exports = { buildEpg, guideSourceUrl, fillStops, inWindow };
+module.exports = { buildEpg, normalizeName, fillStops, inWindow };

--- a/pipeline/src/epg/build.js
+++ b/pipeline/src/epg/build.js
@@ -1,0 +1,134 @@
+'use strict';
+/**
+ * U2 — EPG build: guides.json + XMLTV → mapped, windowed, per-country compact
+ * schedules + per-scope coverage (origin R1, R3, R6, R7, R8).
+ *
+ * Pure-ish: the XMLTV fetcher is injected so this is fully unit-testable with no
+ * network. Deduplicates fetches by source URL, maps source channel ids back to
+ * iptv-org channel ids (site_id or iptv id), and degrades silently where data
+ * is missing (unmapped/scheduleless channels are simply absent — origin R7).
+ */
+const { parseXmltv } = require('./xmltv');
+const { toStorageCountryCode } = require('../schema');
+
+const HOUR_MS = 3600 * 1000;
+const DEFAULT_BRACKET_HOURS = 36; // ±1 source-day, generous for far-offset viewers
+
+/** Prefer an XMLTV source url from a guide entry's sources[] (format XML first). */
+function guideSourceUrl(guide) {
+  const sources = Array.isArray(guide.sources) ? guide.sources : [];
+  const xml = sources.find((s) => s && s.url && /xml/i.test(s.format || '')) || sources.find((s) => s && s.url);
+  return xml ? xml.url : null;
+}
+
+/** Fill missing stops from the next programme's start; sort by start. */
+function fillStops(programmes) {
+  const sorted = programmes.slice().sort((a, b) => a.startUtcMs - b.startUtcMs);
+  for (let i = 0; i < sorted.length; i++) {
+    if (sorted[i].stopUtcMs == null && i + 1 < sorted.length) {
+      sorted[i].stopUtcMs = sorted[i + 1].startUtcMs;
+    }
+  }
+  return sorted;
+}
+
+/** Keep programmes overlapping [windowStart, windowEnd) (a boundary-spanner survives). */
+function inWindow(programmes, windowStart, windowEnd) {
+  return programmes.filter((p) => {
+    const stop = p.stopUtcMs == null ? p.startUtcMs : p.stopUtcMs;
+    return stop > windowStart && p.startUtcMs < windowEnd;
+  });
+}
+
+/** Strip to the compact stored shape (matches the app's Programme type). */
+function compact(p) {
+  const rec = { startUtcMs: p.startUtcMs, stopUtcMs: p.stopUtcMs, title: p.title };
+  if (p.category) rec.category = p.category;
+  return rec;
+}
+
+/**
+ * @param {object} args
+ * @param {Array<{id:string,country:string}>} args.channels   catalog channels (raw country ok)
+ * @param {Array<object>} args.guides                          iptv-org guides.json entries
+ * @param {string[]} args.coveredCountries                     storage country codes to process
+ * @param {(url:string)=>Promise<string>} args.fetchText       XMLTV fetcher (injected)
+ * @param {number} args.now                                    UTC ms reference for the window
+ * @param {number} [args.bracketHours]
+ * @returns {Promise<{shardsByCountry:Object, coverage:Object}>}
+ */
+async function buildEpg({ channels, guides, coveredCountries, fetchText, now, bracketHours = DEFAULT_BRACKET_HOURS }) {
+  const covered = new Set(coveredCountries);
+  const bracketMs = bracketHours * HOUR_MS;
+  const windowStart = now - bracketMs;
+  const windowEnd = now + bracketMs;
+
+  // channel id → storage country, scoped to covered countries.
+  const countryOf = new Map();
+  const scopeCounts = new Map(); // country → total scope channels
+  for (const ch of channels) {
+    const code = toStorageCountryCode(ch.country);
+    if (!covered.has(code)) continue;
+    countryOf.set(ch.id, code);
+    scopeCounts.set(code, (scopeCounts.get(code) || 0) + 1);
+  }
+
+  // Group covered channels' guide entries by their (deduped) source URL.
+  // urlToEntries: url → [{ iptvId, siteId, lang }]
+  const urlToEntries = new Map();
+  for (const g of guides) {
+    if (!g.channel || !countryOf.has(g.channel)) continue;
+    const url = guideSourceUrl(g);
+    if (!url) continue;
+    if (!urlToEntries.has(url)) urlToEntries.set(url, []);
+    urlToEntries.get(url).push({ iptvId: g.channel, siteId: g.site_id, lang: g.lang });
+  }
+
+  // Accumulate programmes per iptv channel id.
+  const byChannel = new Map();
+  for (const [url, entries] of urlToEntries) {
+    let doc;
+    try {
+      doc = await fetchText(url);
+    } catch {
+      continue; // best-effort: one bad source must not sink the whole build
+    }
+    // Build a source-channel-id → iptv-id lookup (try site_id and the iptv id itself).
+    const lookup = new Map();
+    for (const e of entries) {
+      if (e.siteId) lookup.set(e.siteId, e.iptvId);
+      lookup.set(e.iptvId, e.iptvId);
+    }
+    const lang = entries[0] && entries[0].lang;
+    for (const prog of parseXmltv(doc, { lang })) {
+      const iptvId = lookup.get(prog.sourceChannelId);
+      if (!iptvId) continue; // unmapped → drop (silent, never wrong)
+      if (!byChannel.has(iptvId)) byChannel.set(iptvId, []);
+      byChannel.get(iptvId).push(prog);
+    }
+  }
+
+  // Window + compact + group by country.
+  const shardsByCountry = {};
+  const withSchedule = new Map(); // country → count of channels that got a schedule
+  for (const [iptvId, programmes] of byChannel) {
+    const country = countryOf.get(iptvId);
+    if (!country) continue;
+    const windowed = inWindow(fillStops(programmes), windowStart, windowEnd);
+    if (windowed.length === 0) continue;
+    if (!shardsByCountry[country]) shardsByCountry[country] = {};
+    shardsByCountry[country][iptvId] = windowed.map(compact);
+    withSchedule.set(country, (withSchedule.get(country) || 0) + 1);
+  }
+
+  // Coverage = channels-with-schedule / total-scope-channels, per covered country.
+  const coverage = {};
+  for (const code of covered) {
+    const total = scopeCounts.get(code) || 0;
+    coverage[code] = total > 0 ? (withSchedule.get(code) || 0) / total : 0;
+  }
+
+  return { shardsByCountry, coverage };
+}
+
+module.exports = { buildEpg, guideSourceUrl, fillStops, inWindow };

--- a/pipeline/src/epg/build.js
+++ b/pipeline/src/epg/build.js
@@ -87,6 +87,7 @@ async function buildEpg({ channels, coveredCountries, fetchBundle, now, bracketH
 
   const shardsByCountry = {};
   const coverage = {};
+  const fetched = []; // countries whose bundle actually loaded (fetched ok, even if 0 matches)
 
   for (const code of coveredCountries) {
     const scope = scopeByCountry.get(code) || { total: 0, nameToId: new Map() };
@@ -97,15 +98,21 @@ async function buildEpg({ channels, coveredCountries, fetchBundle, now, bracketH
     try {
       xml = await fetchBundle(code);
     } catch {
-      continue; // best-effort: one bad region must not sink the others
+      continue; // fetch failed → leave any prior shard in place (do not clear)
     }
-    if (!xml) continue;
+    if (xml == null) continue; // region not published → keep prior shard
+    fetched.push(code);
 
-    // epg.pw channel id → our iptv id, via normalized display-name.
+    // epg.pw channel id → our iptv id, via normalized display-name. Dedupe so an
+    // HD/SD pair (e.g. "BBC One" + "BBC One HD") doesn't merge two schedules into
+    // one catalog channel — the first epg channel to claim an iptv id wins.
     const epgIdToIptv = new Map();
+    const claimed = new Set();
     for (const c of parseXmltvChannels(xml)) {
       const iptvId = scope.nameToId.get(normalizeName(c.name));
-      if (iptvId) epgIdToIptv.set(c.id, iptvId);
+      if (!iptvId || claimed.has(iptvId)) continue;
+      epgIdToIptv.set(c.id, iptvId);
+      claimed.add(iptvId);
     }
 
     // Group programmes by iptv channel id.
@@ -127,11 +134,13 @@ async function buildEpg({ channels, coveredCountries, fetchBundle, now, bracketH
       withSchedule++;
     }
 
-    if (withSchedule > 0) shardsByCountry[code] = shard;
+    // Always record a shard for a fetched country (possibly empty) so the publish
+    // step overwrites any stale prior shard rather than leaving it.
+    shardsByCountry[code] = shard;
     coverage[code] = withSchedule / scope.total;
   }
 
-  return { shardsByCountry, coverage };
+  return { shardsByCountry, coverage, fetched };
 }
 
 module.exports = { buildEpg, normalizeName, fillStops, inWindow };

--- a/pipeline/src/epg/publish.js
+++ b/pipeline/src/epg/publish.js
@@ -1,0 +1,52 @@
+'use strict';
+/**
+ * U3 — Publish EPG shards + meta to KV (origin R2, R6).
+ *
+ * Mirrors publish-kv.js's "no partial publish" invariant: all epg:<country>
+ * shards are written first, then epg-meta last, so a consumer never sees the
+ * coverage/config pointer advertised as ready before its shards exist.
+ *
+ * `kv` and `purge` are injected for testability (kv.put(key, value) => Promise).
+ */
+const { kvKey } = require('../schema');
+
+/**
+ * @param {object} args
+ * @param {Object} args.shardsByCountry   { [country]: { [channelId]: Programme[] } }
+ * @param {Object} args.coverage          { [country]: number }
+ * @param {string} args.generatedAt
+ * @param {object} args.config            { coverageThreshold, minAiring, bracketHours }
+ * @param {{ put(key:string, value:string): Promise<void> }} args.kv
+ * @param {() => Promise<void>} [args.purge]
+ * @returns {Promise<{ written:number, purged:boolean }>}
+ */
+async function publishEpg({ shardsByCountry, coverage, generatedAt, config, kv, purge }) {
+  let written = 0;
+  const put = async (key, value) => {
+    await kv.put(key, JSON.stringify(value));
+    written++;
+  };
+
+  // 1. Data shards first.
+  for (const [country, shard] of Object.entries(shardsByCountry)) {
+    await put(kvKey.epg(country), shard);
+  }
+
+  // 2. Meta last — flips the "ready" pointer (coverage + config) only once shards exist.
+  await put(kvKey.epgMeta(), { generatedAt, coverage, config });
+
+  // 3. Best-effort cache invalidation (a purge failure must not fail the publish).
+  let purged = false;
+  if (typeof purge === 'function') {
+    try {
+      await purge();
+      purged = true;
+    } catch (err) {
+      console.warn(`EPG cache purge failed (non-fatal; TTL bounds staleness): ${err.message}`);
+    }
+  }
+
+  return { written, purged };
+}
+
+module.exports = { publishEpg };

--- a/pipeline/src/epg/run.js
+++ b/pipeline/src/epg/run.js
@@ -25,13 +25,17 @@ const EPGPW_BASE = 'https://epg.pw/xmltv';
 const FETCH_ATTEMPTS = 3;
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+const FETCH_TIMEOUT_MS = 60000; // bundles are large (~20MB gz); generous but bounded
+
 /** Fetch + gunzip a per-region epg.pw XMLTV bundle (e.g. gb → epg_GB.xml.gz). */
 async function defaultFetchBundle(code) {
   const url = `${EPGPW_BASE}/epg_${String(code).toUpperCase()}.xml.gz`;
   let lastErr;
   for (let attempt = 1; attempt <= FETCH_ATTEMPTS; attempt++) {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS); // guard a stalled/hung body
     try {
-      const res = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0 iptv-viewer-epg/2.0' } });
+      const res = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0 iptv-viewer-epg/2.0' }, signal: ctrl.signal });
       if (res.status === 404) return null; // region not published by epg.pw → no data
       if (res.status !== 200) throw new Error(`XMLTV fetch ${url}: HTTP ${res.status}`);
       const buf = Buffer.from(await res.arrayBuffer());
@@ -39,6 +43,8 @@ async function defaultFetchBundle(code) {
     } catch (err) {
       lastErr = err;
       if (attempt < FETCH_ATTEMPTS) await sleep(1500 * attempt);
+    } finally {
+      clearTimeout(timer);
     }
   }
   throw lastErr;
@@ -63,6 +69,7 @@ async function runEpg(deps) {
   // Name-matching needs the catalog's channel names + countries (not guides.json,
   // whose hosted sources[].url is empty in practice — see build.js).
   const channels = await deps.fetchJson(ENDPOINTS.channels);
+  if (!Array.isArray(channels)) throw new Error('channels.json did not return an array');
 
   const { shardsByCountry, coverage } = await buildEpg({
     channels,
@@ -72,19 +79,29 @@ async function runEpg(deps) {
     bracketHours: config.bracketHours,
   });
 
+  const channelCount = Object.values(shardsByCountry).reduce((n, s) => n + Object.keys(s).length, 0);
+
   let publish = null;
+  let skipped = false;
   if (deps.kv) {
-    publish = await publishEpg({
-      shardsByCountry,
-      coverage,
-      generatedAt: deps.generatedAt,
-      config,
-      kv: deps.kv,
-      purge: deps.purge,
-    });
+    if (channelCount === 0) {
+      // Degenerate result (epg.pw outage, corrupt gzip, or zero matches everywhere):
+      // do NOT overwrite the previously-published guide with an empty one. Skip and
+      // let the next run self-heal — the catalog pipeline's "no empty publish" stance.
+      skipped = true;
+    } else {
+      publish = await publishEpg({
+        shardsByCountry,
+        coverage,
+        generatedAt: deps.generatedAt,
+        config,
+        kv: deps.kv,
+        purge: deps.purge,
+      });
+    }
   }
 
-  return { shardsByCountry, coverage, config, publish };
+  return { shardsByCountry, coverage, config, publish, skipped, channelCount };
 }
 
 // ---- CLI wrapper (not unit-tested beyond runEpg) ------------------------------
@@ -93,7 +110,10 @@ async function main() {
   const now = Date.now();
   const generatedAt = new Date(now).toISOString();
   const kv = process.env.CF_API_TOKEN ? require('../cf-kv').makeKvClient() : null;
-  const purge = process.env.CF_API_TOKEN ? require('../cf-kv').makePurge() : null;
+  // NB: intentionally NO cache purge. EPG is read client-side with a short
+  // staleTime and isn't baked into SSR HTML, so it needs no edge purge — and the
+  // catalog's purge is purge_everything (zone-wide), which would cold-flush the
+  // whole catalog edge cache 4×/day if reused here.
 
   const result = await runEpg({
     fetchJson: defaultFetchJson,
@@ -101,14 +121,12 @@ async function main() {
     now,
     generatedAt,
     kv,
-    purge,
   });
 
-  const countries = Object.keys(result.shardsByCountry);
-  const channelCount = countries.reduce((n, c) => n + Object.keys(result.shardsByCountry[c]).length, 0);
   const cov = Object.entries(result.coverage).map(([c, f]) => `${c}:${(f * 100).toFixed(0)}%`).join(' ');
-  console.log(`EPG: ${channelCount} channels across ${countries.length} countries | coverage ${cov}`);
-  if (result.publish) console.log(`EPG published: ${result.publish.written} keys, purged=${result.publish.purged}`);
+  console.log(`EPG: ${result.channelCount} channels with schedules | coverage ${cov}`);
+  if (result.publish) console.log(`EPG published: ${result.publish.written} keys`);
+  else if (result.skipped) console.log('EPG NOT published — degenerate (empty) result; previous guide preserved.');
   else console.log('EPG dry-run (no CF_API_TOKEN) — nothing published.');
 }
 

--- a/pipeline/src/epg/run.js
+++ b/pipeline/src/epg/run.js
@@ -1,0 +1,122 @@
+'use strict';
+/**
+ * U3 — EPG orchestration + CLI (origin R2, R12).
+ *
+ * runEpg() is the deps-injected orchestrator (testable without network/KV).
+ * main() wires the real iptv-org fetch, XMLTV fetch, and Cloudflare KV client,
+ * and runs on its OWN schedule (.github/workflows/v2-epg.yml) — fully decoupled
+ * from the daily catalog pipeline: it reads guides.json/channels.json live and
+ * writes only epg:* keys, so a catalog anomaly-pause never blocks an EPG refresh.
+ */
+const zlib = require('zlib');
+const { ENDPOINTS } = require('../schema');
+const { defaultFetchJson } = require('../ingest');
+const { buildEpg } = require('./build');
+const { publishEpg } = require('./publish');
+
+// epg.pw's strongest-coverage regions intersected with our catalog at runtime.
+const DEFAULT_COVERED = ['us', 'gb', 'in', 'au', 'ca', 'fr', 'de'];
+// Calibrated against a live epg.pw GB run (~22% of the catalog has a schedule),
+// so the board gate is reachable in strong regions. All three are tunable via
+// epg-meta config without a code change.
+const DEFAULT_CONFIG = { coverageThreshold: 0.2, minAiring: 5, bracketHours: 36 };
+
+const EPGPW_BASE = 'https://epg.pw/xmltv';
+const FETCH_ATTEMPTS = 3;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** Fetch + gunzip a per-region epg.pw XMLTV bundle (e.g. gb → epg_GB.xml.gz). */
+async function defaultFetchBundle(code) {
+  const url = `${EPGPW_BASE}/epg_${String(code).toUpperCase()}.xml.gz`;
+  let lastErr;
+  for (let attempt = 1; attempt <= FETCH_ATTEMPTS; attempt++) {
+    try {
+      const res = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0 iptv-viewer-epg/2.0' } });
+      if (res.status === 404) return null; // region not published by epg.pw → no data
+      if (res.status !== 200) throw new Error(`XMLTV fetch ${url}: HTTP ${res.status}`);
+      const buf = Buffer.from(await res.arrayBuffer());
+      return zlib.gunzipSync(buf).toString('utf8');
+    } catch (err) {
+      lastErr = err;
+      if (attempt < FETCH_ATTEMPTS) await sleep(1500 * attempt);
+    }
+  }
+  throw lastErr;
+}
+
+/**
+ * @param {object} deps
+ * @param {(url:string)=>Promise<any>} deps.fetchJson          iptv-org channels.json (id, name, country)
+ * @param {(code:string)=>Promise<string|null>} deps.fetchBundle  per-country XMLTV fetcher
+ * @param {string[]} [deps.coveredCountries]
+ * @param {object} [deps.config]
+ * @param {number} deps.now
+ * @param {string} deps.generatedAt
+ * @param {object} [deps.kv]              KV client (publish path only)
+ * @param {Function} [deps.purge]
+ * @returns {Promise<object>} build result + publish summary
+ */
+async function runEpg(deps) {
+  const coveredCountries = deps.coveredCountries || DEFAULT_COVERED;
+  const config = { ...DEFAULT_CONFIG, ...(deps.config || {}) };
+
+  // Name-matching needs the catalog's channel names + countries (not guides.json,
+  // whose hosted sources[].url is empty in practice — see build.js).
+  const channels = await deps.fetchJson(ENDPOINTS.channels);
+
+  const { shardsByCountry, coverage } = await buildEpg({
+    channels,
+    coveredCountries,
+    fetchBundle: deps.fetchBundle,
+    now: deps.now,
+    bracketHours: config.bracketHours,
+  });
+
+  let publish = null;
+  if (deps.kv) {
+    publish = await publishEpg({
+      shardsByCountry,
+      coverage,
+      generatedAt: deps.generatedAt,
+      config,
+      kv: deps.kv,
+      purge: deps.purge,
+    });
+  }
+
+  return { shardsByCountry, coverage, config, publish };
+}
+
+// ---- CLI wrapper (not unit-tested beyond runEpg) ------------------------------
+
+async function main() {
+  const now = Date.now();
+  const generatedAt = new Date(now).toISOString();
+  const kv = process.env.CF_API_TOKEN ? require('../cf-kv').makeKvClient() : null;
+  const purge = process.env.CF_API_TOKEN ? require('../cf-kv').makePurge() : null;
+
+  const result = await runEpg({
+    fetchJson: defaultFetchJson,
+    fetchBundle: defaultFetchBundle,
+    now,
+    generatedAt,
+    kv,
+    purge,
+  });
+
+  const countries = Object.keys(result.shardsByCountry);
+  const channelCount = countries.reduce((n, c) => n + Object.keys(result.shardsByCountry[c]).length, 0);
+  const cov = Object.entries(result.coverage).map(([c, f]) => `${c}:${(f * 100).toFixed(0)}%`).join(' ');
+  console.log(`EPG: ${channelCount} channels across ${countries.length} countries | coverage ${cov}`);
+  if (result.publish) console.log(`EPG published: ${result.publish.written} keys, purged=${result.publish.purged}`);
+  else console.log('EPG dry-run (no CF_API_TOKEN) — nothing published.');
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('EPG job failed:', err);
+    process.exit(1);
+  });
+}
+
+module.exports = { runEpg, defaultFetchBundle, DEFAULT_COVERED, DEFAULT_CONFIG };

--- a/pipeline/src/epg/xmltv.js
+++ b/pipeline/src/epg/xmltv.js
@@ -47,6 +47,9 @@ function pickTitle(titles, lang) {
   return (en || titles[0]).text;
 }
 
+const CHANNEL_RE = /<channel\b([^>]*)>([\s\S]*?)<\/channel>/g;
+const DISPLAY_NAME_RE = /<display-name\b[^>]*>([\s\S]*?)<\/display-name>/;
+
 const PROGRAMME_RE = /<programme\b([^>]*)>([\s\S]*?)<\/programme>/g;
 const ATTR_RE = /(\w[\w-]*)="([^"]*)"/g;
 const TITLE_RE = /<title\b([^>]*)>([\s\S]*?)<\/title>/g;
@@ -57,6 +60,26 @@ function attrs(s) {
   let m;
   ATTR_RE.lastIndex = 0;
   while ((m = ATTR_RE.exec(s))) out[m[1]] = m[2];
+  return out;
+}
+
+/**
+ * Parse the `<channel id><display-name>` map from an XMLTV document.
+ * Source feeds (e.g. epg.pw) key programmes by their own channel id, so we need
+ * the id→name map to bridge those ids to our catalog by channel name.
+ * @returns {Array<{id:string, name:string}>}
+ */
+function parseXmltvChannels(doc) {
+  if (typeof doc !== 'string' || doc.length === 0) return [];
+  const out = [];
+  let cm;
+  CHANNEL_RE.lastIndex = 0;
+  while ((cm = CHANNEL_RE.exec(doc))) {
+    const id = attrs(cm[1]).id;
+    if (!id) continue;
+    const nameM = cm[2].match(DISPLAY_NAME_RE);
+    out.push({ id, name: nameM ? decodeEntities(nameM[1]).trim() : '' });
+  }
   return out;
 }
 
@@ -105,4 +128,4 @@ function parseXmltv(doc, opts = {}) {
   return out;
 }
 
-module.exports = { parseXmltv, parseXmltvTime, decodeEntities };
+module.exports = { parseXmltv, parseXmltvChannels, parseXmltvTime, decodeEntities };

--- a/pipeline/src/epg/xmltv.js
+++ b/pipeline/src/epg/xmltv.js
@@ -1,0 +1,108 @@
+'use strict';
+/**
+ * U1 — XMLTV parse + UTC normalization (EPG, origin R1, R3).
+ *
+ * Zero-dependency by design: the pipeline runs on Node built-ins with no install
+ * step (see .github/workflows/ci.yml), so rather than pull in an XML parser we
+ * extract the regular <programme> structure that XMLTV grabbers emit. Pure
+ * functions over a string so they are fully unit-testable with fixtures.
+ */
+
+const ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'" };
+
+/** Decode the XML entities XMLTV text can carry (named + numeric). */
+function decodeEntities(s) {
+  return s.replace(/&(#x?[0-9a-fA-F]+|\w+);/g, (m, body) => {
+    if (body[0] === '#') {
+      const code = body[1] === 'x' || body[1] === 'X' ? parseInt(body.slice(2), 16) : parseInt(body.slice(1), 10);
+      return Number.isFinite(code) ? String.fromCodePoint(code) : m;
+    }
+    return ENTITIES[body] != null ? ENTITIES[body] : m;
+  });
+}
+
+/**
+ * Parse an XMLTV timestamp ("YYYYMMDDHHMMSS +HHMM") to an absolute UTC instant
+ * in ms, or null when it can't be resolved. The offset is REQUIRED — a missing
+ * offset is ambiguous (many feeds mean local time), so we refuse to guess UTC.
+ */
+function parseXmltvTime(value) {
+  if (typeof value !== 'string') return null;
+  const m = value.trim().match(/^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})\s*([+-])(\d{2})(\d{2})$/);
+  if (!m) return null;
+  const [, y, mo, d, h, mi, s, sign, oh, om] = m;
+  // Treat the wall-clock components as UTC, then subtract the zone offset to get
+  // the true UTC instant. (+0500 means 5h ahead of UTC → subtract 5h.)
+  const wall = Date.UTC(+y, +mo - 1, +d, +h, +mi, +s);
+  const offsetMs = (sign === '-' ? -1 : 1) * (+oh * 60 + +om) * 60000;
+  return wall - offsetMs;
+}
+
+/** Pick the best <title> text for a requested language: lang → 'en' → first. */
+function pickTitle(titles, lang) {
+  if (titles.length === 0) return null;
+  const byLang = lang && titles.find((t) => t.lang === lang);
+  if (byLang) return byLang.text;
+  const en = titles.find((t) => t.lang === 'en');
+  return (en || titles[0]).text;
+}
+
+const PROGRAMME_RE = /<programme\b([^>]*)>([\s\S]*?)<\/programme>/g;
+const ATTR_RE = /(\w[\w-]*)="([^"]*)"/g;
+const TITLE_RE = /<title\b([^>]*)>([\s\S]*?)<\/title>/g;
+const TAG_RE = (tag) => new RegExp(`<${tag}\\b[^>]*>([\\s\\S]*?)</${tag}>`);
+
+function attrs(s) {
+  const out = {};
+  let m;
+  ATTR_RE.lastIndex = 0;
+  while ((m = ATTR_RE.exec(s))) out[m[1]] = m[2];
+  return out;
+}
+
+/**
+ * Parse an XMLTV document into normalized programmes. A programme whose start
+ * can't resolve to an absolute UTC instant is DROPPED (silent degradation,
+ * origin R7) rather than rendered with a wrong time.
+ *
+ * @param {string} doc            XMLTV text
+ * @param {{lang?: string}} [opts] preferred title language
+ * @returns {Array<{sourceChannelId:string,startUtcMs:number,stopUtcMs:number|null,title:string|null,desc?:string,category?:string}>}
+ */
+function parseXmltv(doc, opts = {}) {
+  if (typeof doc !== 'string' || doc.length === 0) return [];
+  const out = [];
+  let pm;
+  PROGRAMME_RE.lastIndex = 0;
+  while ((pm = PROGRAMME_RE.exec(doc))) {
+    const a = attrs(pm[1]);
+    const body = pm[2];
+
+    const startUtcMs = parseXmltvTime(a.start);
+    if (startUtcMs == null) continue; // unresolvable time → drop, never guess
+    const stopUtcMs = a.stop ? parseXmltvTime(a.stop) : null;
+
+    const titles = [];
+    let tm;
+    TITLE_RE.lastIndex = 0;
+    while ((tm = TITLE_RE.exec(body))) {
+      titles.push({ lang: attrs(tm[1]).lang || null, text: decodeEntities(tm[2]).trim() });
+    }
+
+    const descM = body.match(TAG_RE('desc'));
+    const catM = body.match(TAG_RE('category'));
+
+    const rec = {
+      sourceChannelId: a.channel || '',
+      startUtcMs,
+      stopUtcMs,
+      title: pickTitle(titles, opts.lang),
+    };
+    if (descM) rec.desc = decodeEntities(descM[1]).trim();
+    if (catM) rec.category = decodeEntities(catM[1]).trim();
+    out.push(rec);
+  }
+  return out;
+}
+
+module.exports = { parseXmltv, parseXmltvTime, decodeEntities };

--- a/pipeline/src/schema.js
+++ b/pipeline/src/schema.js
@@ -55,6 +55,10 @@ const kvKey = {
   category: (slug) => `category:${String(slug).toLowerCase()}`,
   channelIndex: () => 'channel-index',
   meta: () => 'meta',
+  // EPG keys live under their own prefix and are written by the separate,
+  // faster EPG job — never mixed with the daily catalog snapshot keys above.
+  epg: (code) => `epg:${String(code).toLowerCase()}`,
+  epgMeta: () => 'epg-meta',
 };
 
 /** A permissive http(s) URL guard (origin R14). */

--- a/pipeline/test/epg-build.test.js
+++ b/pipeline/test/epg-build.test.js
@@ -1,122 +1,136 @@
 'use strict';
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { buildEpg } = require('../src/epg/build');
+const { buildEpg, normalizeName } = require('../src/epg/build');
 
 const NOW = Date.UTC(2026, 5, 30, 14, 45, 0); // 2026-06-30 14:45 UTC
 
-// A tiny XMLTV doc generator keyed by the source channel id.
-function xmltv(channelId, programmes) {
-  const body = programmes
-    .map((p) => `<programme start="${p.start}"${p.stop ? ` stop="${p.stop}"` : ''} channel="${channelId}"><title lang="en">${p.title}</title></programme>`)
+// A tiny epg.pw-style bundle: <channel id><display-name> + programmes by that id.
+function bundle(channels, programmes) {
+  const chans = channels.map((c) => `<channel id="${c.id}"><display-name>${c.name}</display-name></channel>`).join('');
+  const progs = programmes
+    .map((p) => `<programme start="${p.start}"${p.stop ? ` stop="${p.stop}"` : ''} channel="${p.ch}"><title lang="en">${p.title}</title></programme>`)
     .join('');
-  return `<tv>${body}</tv>`;
+  return `<tv>${chans}${progs}</tv>`;
 }
 
 function baseArgs(overrides = {}) {
   return {
     channels: [
-      { id: 'BBCOne.uk', country: 'UK' },
-      { id: 'ITV.uk', country: 'GB' },
-      { id: 'NoGuide.uk', country: 'GB' },
-      { id: 'Other.fr', country: 'FR' },
-    ],
-    guides: [
-      { channel: 'BBCOne.uk', site: 'epg.pw', site_id: 'bbc1', lang: 'en', sources: [{ host: 'epg.pw', url: 'https://epg.pw/epg_GB.xml', format: 'XML' }] },
-      { channel: 'ITV.uk', site: 'epg.pw', site_id: 'itv1', lang: 'en', sources: [{ host: 'epg.pw', url: 'https://epg.pw/epg_GB.xml', format: 'XML' }] },
+      { id: 'BBCOne.uk', name: 'BBC One', country: 'UK' },
+      { id: 'SkyWitness.uk', name: 'Sky Witness', country: 'GB' },
+      { id: 'NoEpg.uk', name: 'No Epg Channel', country: 'GB' },
+      { id: 'Other.fr', name: 'France 2', country: 'FR' },
     ],
     coveredCountries: ['gb'],
     now: NOW,
     bracketHours: 36,
-    fetchText: async (url) => {
-      assert.equal(url, 'https://epg.pw/epg_GB.xml');
-      // One regional bundle keyed by site_id, serving both channels.
-      return (
-        xmltv('bbc1', [
-          { start: '20260630143000 +0000', stop: '20260630150000 +0000', title: 'BBC Now' },
-          { start: '20260630150000 +0000', stop: '20260630160000 +0000', title: 'BBC Next' },
-        ]) +
-        xmltv('itv1', [{ start: '20260630140000 +0000', stop: '20260630150000 +0000', title: 'ITV Now' }])
-      ).replace(/<\/?tv>/g, '');
+    fetchBundle: async (code) => {
+      assert.equal(code, 'gb');
+      return bundle(
+        [
+          { id: '100', name: 'BBC One HD' }, // matches "BBC One" after HD-strip
+          { id: '200', name: 'Sky Witness HD' }, // matches "Sky Witness"
+          { id: '999', name: 'Unmatched Channel' },
+        ],
+        [
+          { ch: '100', start: '20260630143000 +0000', stop: '20260630150000 +0000', title: 'BBC Now' },
+          { ch: '100', start: '20260630150000 +0000', stop: '20260630160000 +0000', title: 'BBC Next' },
+          { ch: '200', start: '20260630140000 +0000', stop: '20260630150000 +0000', title: 'Sky Now' },
+          { ch: '999', start: '20260630140000 +0000', stop: '20260630150000 +0000', title: 'Orphan' },
+        ],
+      );
     },
+    ...overrides,
   };
 }
 
-test('happy path: maps programmes via site_id and shards by country', async () => {
+test('normalizeName: strips quality tokens, punctuation, case', () => {
+  assert.equal(normalizeName('Sky Witness HD'), 'skywitness');
+  assert.equal(normalizeName('BBC One'), 'bbcone');
+  assert.equal(normalizeName('That’s TV 4K'), 'thatstv');
+});
+
+test('happy path: name-matches epg.pw channels to catalog and shards by country', async () => {
   const { shardsByCountry } = await buildEpg(baseArgs());
   const gb = shardsByCountry.gb;
-  assert.ok(gb['BBCOne.uk'], 'BBC mapped via site_id bbc1');
-  assert.ok(gb['ITV.uk'], 'ITV mapped via site_id itv1');
+  assert.ok(gb['BBCOne.uk'], 'BBC One HD matched BBC One');
+  assert.ok(gb['SkyWitness.uk'], 'Sky Witness HD matched Sky Witness');
   assert.equal(gb['BBCOne.uk'][0].title, 'BBC Now');
   assert.equal(gb['BBCOne.uk'][0].startUtcMs, Date.UTC(2026, 5, 30, 14, 30, 0));
 });
 
-test('dedup: a shared source URL is fetched exactly once', async () => {
-  let calls = 0;
-  const args = baseArgs();
-  const inner = args.fetchText;
-  args.fetchText = async (url) => {
-    calls++;
-    return inner(url);
-  };
-  await buildEpg(args);
-  assert.equal(calls, 1, 'both channels share one URL → one fetch');
+test('an epg.pw channel with no catalog name-match is dropped (silent)', async () => {
+  const { shardsByCountry } = await buildEpg(baseArgs());
+  // The "Unmatched Channel" (id 999) programme never lands on any catalog channel.
+  const ids = Object.keys(shardsByCountry.gb);
+  assert.ok(!ids.includes('999'));
+  assert.equal(shardsByCountry.gb['NoEpg.uk'], undefined, 'catalog channel with no epg match absent');
 });
 
-test('coverage: fraction of scope channels with a schedule', async () => {
+test('coverage: matched-with-schedule / total scope channels', async () => {
   const { coverage } = await buildEpg(baseArgs());
-  // GB scope has 3 channels (ITV.uk, NoGuide.uk, BBCOne.uk after UK→GB); 2 have schedules.
+  // GB scope = BBCOne.uk, SkyWitness.uk, NoEpg.uk (3); 2 matched with schedules.
   assert.ok(Math.abs(coverage.gb - 2 / 3) < 1e-9, `expected 2/3, got ${coverage.gb}`);
+});
+
+test('fetchBundle called once per covered country', async () => {
+  let calls = 0;
+  const args = baseArgs();
+  const inner = args.fetchBundle;
+  args.fetchBundle = async (c) => {
+    calls++;
+    return inner(c);
+  };
+  await buildEpg(args);
+  assert.equal(calls, 1);
 });
 
 test('missing stop is filled from the next programme start', async () => {
   const args = baseArgs();
-  args.fetchText = async () =>
-    xmltv('bbc1', [
-      { start: '20260630143000 +0000', title: 'No Stop' },
-      { start: '20260630150000 +0000', stop: '20260630160000 +0000', title: 'Has Start' },
-    ]).replace(/<\/?tv>/g, '');
+  args.fetchBundle = async () =>
+    bundle([{ id: '100', name: 'BBC One' }], [
+      { ch: '100', start: '20260630143000 +0000', title: 'No Stop' },
+      { ch: '100', start: '20260630150000 +0000', stop: '20260630160000 +0000', title: 'Has Start' },
+    ]);
   const { shardsByCountry } = await buildEpg(args);
   const progs = shardsByCountry.gb['BBCOne.uk'];
-  assert.equal(progs[0].stopUtcMs, progs[1].startUtcMs, 'filled from next start');
-});
-
-test('a channel with no guide entry is absent from the shard (silent degradation)', async () => {
-  const { shardsByCountry } = await buildEpg(baseArgs());
-  assert.equal(shardsByCountry.gb['NoGuide.uk'], undefined);
+  assert.equal(progs[0].stopUtcMs, progs[1].startUtcMs);
 });
 
 test('bracket window keeps a boundary-spanning programme, drops far-outside ones', async () => {
   const args = baseArgs();
-  args.fetchText = async () =>
-    xmltv('bbc1', [
-      { start: '20260625000000 +0000', stop: '20260625010000 +0000', title: 'Way Before' },
-      { start: '20260630143000 +0000', stop: '20260630150000 +0000', title: 'Now' },
-      { start: '20260720000000 +0000', stop: '20260720010000 +0000', title: 'Way After' },
-    ]).replace(/<\/?tv>/g, '');
+  args.fetchBundle = async () =>
+    bundle([{ id: '100', name: 'BBC One' }], [
+      { ch: '100', start: '20260625000000 +0000', stop: '20260625010000 +0000', title: 'Way Before' },
+      { ch: '100', start: '20260630143000 +0000', stop: '20260630150000 +0000', title: 'Now' },
+      { ch: '100', start: '20260720000000 +0000', stop: '20260720010000 +0000', title: 'Way After' },
+    ]);
   const { shardsByCountry } = await buildEpg(args);
-  const titles = shardsByCountry.gb['BBCOne.uk'].map((p) => p.title);
-  assert.deepEqual(titles, ['Now'], 'only the in-window programme survives');
+  assert.deepEqual(shardsByCountry.gb['BBCOne.uk'].map((p) => p.title), ['Now']);
 });
 
-test('error path: a failing source URL is skipped, others still build', async () => {
+test('error path: a failing region is skipped, others still build', async () => {
   const args = baseArgs();
-  args.guides.push({ channel: 'Other.fr', site: 'epg.pw', site_id: 'o1', lang: 'fr', sources: [{ host: 'epg.pw', url: 'https://epg.pw/epg_FR.xml', format: 'XML' }] });
   args.coveredCountries = ['gb', 'fr'];
-  const inner = args.fetchText;
-  args.fetchText = async (url) => {
-    if (url.includes('FR')) throw new Error('boom');
-    return inner(url);
+  const inner = args.fetchBundle;
+  args.fetchBundle = async (code) => {
+    if (code === 'fr') throw new Error('boom');
+    return inner('gb');
   };
   const { shardsByCountry, coverage } = await buildEpg(args);
   assert.ok(shardsByCountry.gb['BBCOne.uk'], 'GB still built despite FR failure');
-  assert.equal(coverage.fr, 0, 'FR scope ends up with no coverage, not a crash');
+  assert.equal(coverage.fr, 0);
 });
 
 test('only covered countries are processed', async () => {
-  const args = baseArgs();
-  // FR guide present but FR not covered → never fetched.
-  args.guides.push({ channel: 'Other.fr', site: 'epg.pw', site_id: 'o1', lang: 'fr', sources: [{ host: 'epg.pw', url: 'https://epg.pw/epg_FR.xml', format: 'XML' }] });
-  const { shardsByCountry } = await buildEpg(args);
+  const { shardsByCountry } = await buildEpg(baseArgs());
   assert.equal(shardsByCountry.fr, undefined);
+});
+
+test('a null bundle (no data) yields zero coverage, not a crash', async () => {
+  const args = baseArgs({ fetchBundle: async () => null });
+  const { shardsByCountry, coverage } = await buildEpg(args);
+  assert.equal(shardsByCountry.gb, undefined);
+  assert.equal(coverage.gb, 0);
 });

--- a/pipeline/test/epg-build.test.js
+++ b/pipeline/test/epg-build.test.js
@@ -128,9 +128,37 @@ test('only covered countries are processed', async () => {
   assert.equal(shardsByCountry.fr, undefined);
 });
 
-test('a null bundle (no data) yields zero coverage, not a crash', async () => {
+test('a null bundle (no data) yields zero coverage and no shard (prior preserved)', async () => {
   const args = baseArgs({ fetchBundle: async () => null });
-  const { shardsByCountry, coverage } = await buildEpg(args);
-  assert.equal(shardsByCountry.gb, undefined);
+  const { shardsByCountry, coverage, fetched } = await buildEpg(args);
+  assert.equal(shardsByCountry.gb, undefined, 'no shard written → publish leaves any prior shard');
   assert.equal(coverage.gb, 0);
+  assert.deepEqual(fetched, [], 'a null bundle is not counted as fetched');
+});
+
+test('a fetched-but-empty region records an empty shard (clears stale data)', async () => {
+  // Bundle has a channel that matches nothing in the catalog.
+  const args = baseArgs({ fetchBundle: async () => bundle([{ id: '1', name: 'Totally Unknown' }], []) });
+  const { shardsByCountry, fetched } = await buildEpg(args);
+  assert.deepEqual(shardsByCountry.gb, {}, 'empty shard written so the publish overwrites stale');
+  assert.deepEqual(fetched, ['gb']);
+});
+
+test('HD/SD epg variants dedupe to one catalog channel (no doubled listings)', async () => {
+  const args = baseArgs({
+    channels: [{ id: 'BBCOne.uk', name: 'BBC One', country: 'GB' }],
+    fetchBundle: async () =>
+      bundle(
+        [
+          { id: '100', name: 'BBC One' },
+          { id: '101', name: 'BBC One HD' }, // same normalized name → must NOT also map
+        ],
+        [
+          { ch: '100', start: '20260630143000 +0000', stop: '20260630150000 +0000', title: 'A' },
+          { ch: '101', start: '20260630143000 +0000', stop: '20260630150000 +0000', title: 'A (HD dupe)' },
+        ],
+      ),
+  });
+  const { shardsByCountry } = await buildEpg(args);
+  assert.equal(shardsByCountry.gb['BBCOne.uk'].length, 1, 'only the first epg variant is mapped');
 });

--- a/pipeline/test/epg-build.test.js
+++ b/pipeline/test/epg-build.test.js
@@ -1,0 +1,122 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { buildEpg } = require('../src/epg/build');
+
+const NOW = Date.UTC(2026, 5, 30, 14, 45, 0); // 2026-06-30 14:45 UTC
+
+// A tiny XMLTV doc generator keyed by the source channel id.
+function xmltv(channelId, programmes) {
+  const body = programmes
+    .map((p) => `<programme start="${p.start}"${p.stop ? ` stop="${p.stop}"` : ''} channel="${channelId}"><title lang="en">${p.title}</title></programme>`)
+    .join('');
+  return `<tv>${body}</tv>`;
+}
+
+function baseArgs(overrides = {}) {
+  return {
+    channels: [
+      { id: 'BBCOne.uk', country: 'UK' },
+      { id: 'ITV.uk', country: 'GB' },
+      { id: 'NoGuide.uk', country: 'GB' },
+      { id: 'Other.fr', country: 'FR' },
+    ],
+    guides: [
+      { channel: 'BBCOne.uk', site: 'epg.pw', site_id: 'bbc1', lang: 'en', sources: [{ host: 'epg.pw', url: 'https://epg.pw/epg_GB.xml', format: 'XML' }] },
+      { channel: 'ITV.uk', site: 'epg.pw', site_id: 'itv1', lang: 'en', sources: [{ host: 'epg.pw', url: 'https://epg.pw/epg_GB.xml', format: 'XML' }] },
+    ],
+    coveredCountries: ['gb'],
+    now: NOW,
+    bracketHours: 36,
+    fetchText: async (url) => {
+      assert.equal(url, 'https://epg.pw/epg_GB.xml');
+      // One regional bundle keyed by site_id, serving both channels.
+      return (
+        xmltv('bbc1', [
+          { start: '20260630143000 +0000', stop: '20260630150000 +0000', title: 'BBC Now' },
+          { start: '20260630150000 +0000', stop: '20260630160000 +0000', title: 'BBC Next' },
+        ]) +
+        xmltv('itv1', [{ start: '20260630140000 +0000', stop: '20260630150000 +0000', title: 'ITV Now' }])
+      ).replace(/<\/?tv>/g, '');
+    },
+  };
+}
+
+test('happy path: maps programmes via site_id and shards by country', async () => {
+  const { shardsByCountry } = await buildEpg(baseArgs());
+  const gb = shardsByCountry.gb;
+  assert.ok(gb['BBCOne.uk'], 'BBC mapped via site_id bbc1');
+  assert.ok(gb['ITV.uk'], 'ITV mapped via site_id itv1');
+  assert.equal(gb['BBCOne.uk'][0].title, 'BBC Now');
+  assert.equal(gb['BBCOne.uk'][0].startUtcMs, Date.UTC(2026, 5, 30, 14, 30, 0));
+});
+
+test('dedup: a shared source URL is fetched exactly once', async () => {
+  let calls = 0;
+  const args = baseArgs();
+  const inner = args.fetchText;
+  args.fetchText = async (url) => {
+    calls++;
+    return inner(url);
+  };
+  await buildEpg(args);
+  assert.equal(calls, 1, 'both channels share one URL → one fetch');
+});
+
+test('coverage: fraction of scope channels with a schedule', async () => {
+  const { coverage } = await buildEpg(baseArgs());
+  // GB scope has 3 channels (ITV.uk, NoGuide.uk, BBCOne.uk after UK→GB); 2 have schedules.
+  assert.ok(Math.abs(coverage.gb - 2 / 3) < 1e-9, `expected 2/3, got ${coverage.gb}`);
+});
+
+test('missing stop is filled from the next programme start', async () => {
+  const args = baseArgs();
+  args.fetchText = async () =>
+    xmltv('bbc1', [
+      { start: '20260630143000 +0000', title: 'No Stop' },
+      { start: '20260630150000 +0000', stop: '20260630160000 +0000', title: 'Has Start' },
+    ]).replace(/<\/?tv>/g, '');
+  const { shardsByCountry } = await buildEpg(args);
+  const progs = shardsByCountry.gb['BBCOne.uk'];
+  assert.equal(progs[0].stopUtcMs, progs[1].startUtcMs, 'filled from next start');
+});
+
+test('a channel with no guide entry is absent from the shard (silent degradation)', async () => {
+  const { shardsByCountry } = await buildEpg(baseArgs());
+  assert.equal(shardsByCountry.gb['NoGuide.uk'], undefined);
+});
+
+test('bracket window keeps a boundary-spanning programme, drops far-outside ones', async () => {
+  const args = baseArgs();
+  args.fetchText = async () =>
+    xmltv('bbc1', [
+      { start: '20260625000000 +0000', stop: '20260625010000 +0000', title: 'Way Before' },
+      { start: '20260630143000 +0000', stop: '20260630150000 +0000', title: 'Now' },
+      { start: '20260720000000 +0000', stop: '20260720010000 +0000', title: 'Way After' },
+    ]).replace(/<\/?tv>/g, '');
+  const { shardsByCountry } = await buildEpg(args);
+  const titles = shardsByCountry.gb['BBCOne.uk'].map((p) => p.title);
+  assert.deepEqual(titles, ['Now'], 'only the in-window programme survives');
+});
+
+test('error path: a failing source URL is skipped, others still build', async () => {
+  const args = baseArgs();
+  args.guides.push({ channel: 'Other.fr', site: 'epg.pw', site_id: 'o1', lang: 'fr', sources: [{ host: 'epg.pw', url: 'https://epg.pw/epg_FR.xml', format: 'XML' }] });
+  args.coveredCountries = ['gb', 'fr'];
+  const inner = args.fetchText;
+  args.fetchText = async (url) => {
+    if (url.includes('FR')) throw new Error('boom');
+    return inner(url);
+  };
+  const { shardsByCountry, coverage } = await buildEpg(args);
+  assert.ok(shardsByCountry.gb['BBCOne.uk'], 'GB still built despite FR failure');
+  assert.equal(coverage.fr, 0, 'FR scope ends up with no coverage, not a crash');
+});
+
+test('only covered countries are processed', async () => {
+  const args = baseArgs();
+  // FR guide present but FR not covered → never fetched.
+  args.guides.push({ channel: 'Other.fr', site: 'epg.pw', site_id: 'o1', lang: 'fr', sources: [{ host: 'epg.pw', url: 'https://epg.pw/epg_FR.xml', format: 'XML' }] });
+  const { shardsByCountry } = await buildEpg(args);
+  assert.equal(shardsByCountry.fr, undefined);
+});

--- a/pipeline/test/epg-publish.test.js
+++ b/pipeline/test/epg-publish.test.js
@@ -1,0 +1,62 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { publishEpg } = require('../src/epg/publish');
+const { kvKey } = require('../src/schema');
+
+function recordingKv() {
+  const writes = [];
+  return {
+    writes,
+    put: async (key, value) => {
+      writes.push({ key, value });
+    },
+  };
+}
+
+const ARGS = () => ({
+  shardsByCountry: {
+    gb: { 'BBCOne.uk': [{ startUtcMs: 1, stopUtcMs: 2, title: 'X' }] },
+    in: { 'NDTV.in': [{ startUtcMs: 3, stopUtcMs: 4, title: 'Y' }] },
+  },
+  coverage: { gb: 0.5, in: 0.4 },
+  generatedAt: '2026-06-30T12:00:00Z',
+  config: { coverageThreshold: 0.3, minAiring: 5, bracketHours: 36 },
+});
+
+test('writes every epg:<country> shard before epg-meta (no partial publish)', async () => {
+  const kv = recordingKv();
+  const res = await publishEpg({ ...ARGS(), kv });
+  const keys = kv.writes.map((w) => w.key);
+  assert.deepEqual(keys.slice(0, 2).sort(), [kvKey.epg('gb'), kvKey.epg('in')].sort());
+  assert.equal(keys[keys.length - 1], kvKey.epgMeta(), 'meta written last');
+  assert.equal(res.written, 3);
+});
+
+test('epg-meta carries coverage + config', async () => {
+  const kv = recordingKv();
+  await publishEpg({ ...ARGS(), kv });
+  const meta = JSON.parse(kv.writes.find((w) => w.key === kvKey.epgMeta()).value);
+  assert.deepEqual(meta.coverage, { gb: 0.5, in: 0.4 });
+  assert.deepEqual(meta.config, { coverageThreshold: 0.3, minAiring: 5, bracketHours: 36 });
+  assert.equal(meta.generatedAt, '2026-06-30T12:00:00Z');
+});
+
+test('a shard put rejection surfaces and does not flip meta', async () => {
+  const kv = {
+    writes: [],
+    put: async (key, value) => {
+      if (key === kvKey.epg('in')) throw new Error('kv down');
+      kv.writes.push({ key, value });
+    },
+  };
+  await assert.rejects(() => publishEpg({ ...ARGS(), kv }), /kv down/);
+  assert.equal(kv.writes.find((w) => w.key === kvKey.epgMeta()), undefined, 'meta never written on failure');
+});
+
+test('purge failure is non-fatal', async () => {
+  const kv = recordingKv();
+  const res = await publishEpg({ ...ARGS(), kv, purge: async () => { throw new Error('purge boom'); } });
+  assert.equal(res.purged, false);
+  assert.equal(res.written, 3, 'publish still succeeded');
+});

--- a/pipeline/test/epg-run.test.js
+++ b/pipeline/test/epg-run.test.js
@@ -1,0 +1,36 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { runEpg } = require('../src/epg/run');
+const { ENDPOINTS, kvKey } = require('../src/schema');
+
+const NOW = Date.UTC(2026, 5, 30, 14, 45, 0);
+
+function deps(overrides = {}) {
+  const fetchJson = async (url) => {
+    if (url === ENDPOINTS.channels) return [{ id: 'BBCOne.uk', name: 'BBC One', country: 'GB' }];
+    throw new Error(`unexpected json url ${url}`);
+  };
+  const fetchBundle = async (code) => {
+    assert.equal(code, 'gb');
+    return '<tv><channel id="100"><display-name>BBC One HD</display-name></channel>' +
+      '<programme start="20260630143000 +0000" stop="20260630150000 +0000" channel="100"><title lang="en">Now</title></programme></tv>';
+  };
+  return { fetchJson, fetchBundle, coveredCountries: ['gb'], now: NOW, generatedAt: '2026-06-30T12:00:00Z', ...overrides };
+}
+
+test('runEpg dry-run (no kv) builds shards + coverage, publishes nothing', async () => {
+  const res = await runEpg(deps());
+  assert.ok(res.shardsByCountry.gb['BBCOne.uk']);
+  assert.equal(res.coverage.gb, 1);
+  assert.equal(res.publish, null);
+});
+
+test('runEpg with a kv client publishes shards then meta', async () => {
+  const writes = [];
+  const kv = { put: async (key, value) => writes.push({ key, value }) };
+  const res = await runEpg(deps({ kv }));
+  assert.ok(res.publish.written >= 2);
+  assert.equal(writes[0].key, kvKey.epg('gb'));
+  assert.equal(writes[writes.length - 1].key, kvKey.epgMeta());
+});

--- a/pipeline/test/epg-run.test.js
+++ b/pipeline/test/epg-run.test.js
@@ -34,3 +34,20 @@ test('runEpg with a kv client publishes shards then meta', async () => {
   assert.equal(writes[0].key, kvKey.epg('gb'));
   assert.equal(writes[writes.length - 1].key, kvKey.epgMeta());
 });
+
+test('runEpg skips publish on a degenerate (empty) result — protects prior guide', async () => {
+  const writes = [];
+  const kv = { put: async (key, value) => writes.push({ key, value }) };
+  // Bundle matches nothing → channelCount 0 → must NOT publish.
+  const res = await runEpg(deps({ kv, fetchBundle: async () => '<tv><channel id="9"><display-name>Nope</display-name></channel></tv>' }));
+  assert.equal(res.skipped, true);
+  assert.equal(res.publish, null);
+  assert.equal(writes.length, 0, 'nothing written — previous guide preserved');
+});
+
+test('runEpg rejects a non-array channels.json (clear failure, not a TypeError)', async () => {
+  await assert.rejects(
+    () => runEpg(deps({ fetchJson: async () => ({ not: 'an array' }) })),
+    /did not return an array/,
+  );
+});

--- a/pipeline/test/epg-xmltv.test.js
+++ b/pipeline/test/epg-xmltv.test.js
@@ -1,7 +1,7 @@
 'use strict';
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { parseXmltvTime, parseXmltv } = require('../src/epg/xmltv');
+const { parseXmltvTime, parseXmltv, parseXmltvChannels } = require('../src/epg/xmltv');
 
 // --- Time normalization (the silent-failure epicenter — tested first) --------
 
@@ -95,4 +95,16 @@ test('parseXmltv: malformed/empty document returns []', () => {
   assert.deepEqual(parseXmltv(''), []);
   assert.deepEqual(parseXmltv('<tv></tv>'), []);
   assert.deepEqual(parseXmltv('not xml at all'), []);
+});
+
+test('parseXmltvChannels: extracts id → display-name map', () => {
+  const chans = parseXmltvChannels(DOC);
+  assert.equal(chans.length, 1);
+  assert.deepEqual(chans[0], { id: 'bbcone.uk', name: 'BBC One' });
+});
+
+test('parseXmltvChannels: decodes entities and handles empty doc', () => {
+  const doc = '<tv><channel id="9"><display-name>A &amp; B</display-name></channel></tv>';
+  assert.deepEqual(parseXmltvChannels(doc), [{ id: '9', name: 'A & B' }]);
+  assert.deepEqual(parseXmltvChannels(''), []);
 });

--- a/pipeline/test/epg-xmltv.test.js
+++ b/pipeline/test/epg-xmltv.test.js
@@ -1,0 +1,98 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { parseXmltvTime, parseXmltv } = require('../src/epg/xmltv');
+
+// --- Time normalization (the silent-failure epicenter — tested first) --------
+
+test('parseXmltvTime: UTC offset is the identity', () => {
+  // 2026-06-30 14:30:00 +0000 → that exact instant.
+  assert.equal(parseXmltvTime('20260630143000 +0000'), Date.UTC(2026, 5, 30, 14, 30, 0));
+});
+
+test('parseXmltvTime: a positive offset shifts earlier in UTC', () => {
+  // 14:30 +0500 is 09:30 UTC (offset is wall-clock-from-UTC).
+  assert.equal(parseXmltvTime('20260630143000 +0500'), Date.UTC(2026, 5, 30, 9, 30, 0));
+});
+
+test('parseXmltvTime: a negative offset shifts later in UTC', () => {
+  // 14:30 -0500 is 19:30 UTC.
+  assert.equal(parseXmltvTime('20260630143000 -0500'), Date.UTC(2026, 5, 30, 19, 30, 0));
+});
+
+test('parseXmltvTime: half-hour offset (e.g. +0530 India)', () => {
+  assert.equal(parseXmltvTime('20260630143000 +0530'), Date.UTC(2026, 5, 30, 9, 0, 0));
+});
+
+test('parseXmltvTime: missing offset returns null (do not assume UTC)', () => {
+  assert.equal(parseXmltvTime('20260630143000'), null);
+});
+
+test('parseXmltvTime: malformed input returns null', () => {
+  assert.equal(parseXmltvTime('not-a-time'), null);
+  assert.equal(parseXmltvTime(''), null);
+  assert.equal(parseXmltvTime(undefined), null);
+});
+
+test('parseXmltvTime: DST-day instant with explicit offset resolves without double-shift', () => {
+  // A US Eastern spring-forward day; the offset in the string is authoritative.
+  // 2026-03-08 01:30:00 -0500 → 06:30 UTC, regardless of local DST rules.
+  assert.equal(parseXmltvTime('20260308013000 -0500'), Date.UTC(2026, 2, 8, 6, 30, 0));
+});
+
+// --- Programme parsing --------------------------------------------------------
+
+const DOC = `<?xml version="1.0" encoding="UTF-8"?>
+<tv>
+  <channel id="bbcone.uk"><display-name>BBC One</display-name></channel>
+  <programme start="20260630143000 +0000" stop="20260630150000 +0000" channel="bbcone.uk">
+    <title lang="en">News at Six</title>
+    <desc lang="en">The day&apos;s headlines &amp; more.</desc>
+    <category lang="en">News</category>
+  </programme>
+  <programme start="20260630150000 +0000" channel="bbcone.uk">
+    <title lang="fr">Le Film</title>
+    <title lang="en">The Film</title>
+  </programme>
+</tv>`;
+
+test('parseXmltv: extracts programmes with absolute UTC times', () => {
+  const progs = parseXmltv(DOC);
+  assert.equal(progs.length, 2);
+  const p0 = progs[0];
+  assert.equal(p0.sourceChannelId, 'bbcone.uk');
+  assert.equal(p0.startUtcMs, Date.UTC(2026, 5, 30, 14, 30, 0));
+  assert.equal(p0.stopUtcMs, Date.UTC(2026, 5, 30, 15, 0, 0));
+  assert.equal(p0.title, 'News at Six');
+  assert.equal(p0.category, 'News');
+});
+
+test('parseXmltv: decodes XML entities in text', () => {
+  const [p0] = parseXmltv(DOC);
+  assert.equal(p0.desc, "The day's headlines & more.");
+});
+
+test('parseXmltv: missing stop yields null stopUtcMs', () => {
+  const progs = parseXmltv(DOC);
+  assert.equal(progs[1].stopUtcMs, null);
+});
+
+test('parseXmltv: prefers the requested lang title, falls back to en, then first', () => {
+  const progs = parseXmltv(DOC);
+  // Second programme has fr + en; requesting fr picks fr.
+  assert.equal(parseXmltv(DOC, { lang: 'fr' })[1].title, 'Le Film');
+  // Default (no lang) falls back to en.
+  assert.equal(progs[1].title, 'The Film');
+});
+
+test('parseXmltv: programme whose times do not resolve is dropped (no silent bad data)', () => {
+  const doc = `<tv><programme start="20260630143000" channel="x"><title>Untimed</title></programme></tv>`;
+  // start has no offset → unresolvable → dropped.
+  assert.deepEqual(parseXmltv(doc), []);
+});
+
+test('parseXmltv: malformed/empty document returns []', () => {
+  assert.deepEqual(parseXmltv(''), []);
+  assert.deepEqual(parseXmltv('<tv></tv>'), []);
+  assert.deepEqual(parseXmltv('not xml at all'), []);
+});


### PR DESCRIPTION
## What & why

**Phase 1 of the v2 EPG feature** (plan: `docs/plans/2026-06-30-001-feat-v2-epg-plan.md`, requirements: `docs/brainstorms/2026-06-28-v2-epg-requirements.md`) — the **pipeline half**: a new EPG refresh job that turns hosted XMLTV program data into a compact, timezone-correct, per-country schedule in Cloudflare KV, on its own cadence, fully decoupled from the daily catalog snapshot. The app-facing now/next labels + Live-now board + structured data come in Phase 2.

Zero new runtime dependencies — the parser is hand-rolled on Node built-ins, matching the pipeline's no-install ethos (CI runs `node --test` with nothing to `npm ci`).

## The source pivot (validated against live data)

The plan's primary source was `guides.json` `sources[].url` (direct XMLTV URLs, added upstream May 2026). **A live probe during the build found that field is empty in practice — 2 of ~179,675 guide entries carry it.** There's also no `site: epg.pw` bridge in `guides.json`. So I pivoted to the plan's documented fallback, promoted to primary:

- **Source:** epg.pw per-region XMLTV bundles (`epg_<ISO2>.xml.gz`), fetched per covered country.
- **Mapping:** epg.pw keys programmes by its own numeric channel ids + a `<display-name>`, with no id bridge to iptv-org — so channels are matched by **normalized name** within the same country (strip HD/SD/4K, lowercase, drop punctuation).
- **Validated end-to-end against live epg.pw:** GB yields **148 channels with real schedules** (~22% catalog coverage), computing a correct now/next (e.g. `KanshiTV.uk` → "Begumpura Parivaar", 90 programmes in the ±36h window). The default board `coverageThreshold` was calibrated to 0.2 off this run.

`guides.json` precise mapping remains a future upgrade for when upstream populates `sources[].url`.

## What's in this PR

- `pipeline/src/epg/xmltv.js` — zero-dep XMLTV parser + **UTC time normalization** (`YYYYMMDDHHMMSS +HHMM` → absolute epoch; offset required, never guessed; DST-safe), plus `<channel>` display-name extraction.
- `pipeline/src/epg/build.js` — per-country bundle fetch → name-match → fill missing stops → ±36h bracket window → compact per-country shards + per-scope coverage.
- `pipeline/src/epg/publish.js` — KV publish, **data-shards-then-`epg-meta`** (no partial publish), mirroring the catalog `publish-kv.js`.
- `pipeline/src/epg/run.js` — orchestrator + CLI + epg.pw fetch (gunzip, timeout, retry).
- `pipeline/src/schema.js` — `epg:<country>` + `epg-meta` KV keys.
- `.github/workflows/v2-epg.yml` — own cron (every 6h), own concurrency group, same CF secrets — independent of the daily catalog pipeline.

## Testing

- **79 pipeline tests pass** (`npm run test:pipeline`; was 44, +35 for EPG) — UTC/DST normalization, parser edge cases, name-match + dedupe, window/coverage math, data-then-meta ordering, empty-result guard, fetch failures.
- **Live validation** of the real channel-id mapping (the plan's one deferred unknown), as above.

## Review

High-effort multi-agent review (36 agents). **Fixed** the confirmed correctness bugs:
- **Empty-result publish guard** — a degenerate run (epg.pw outage / zero matches) no longer overwrites `epg-meta` with a guide-wide blackout; it skips and self-heals next run.
- **Stale-shard clear** — a fetched-but-empty country writes an empty shard so the publish overwrites prior stale data (a *failed* fetch leaves prior data intact).
- **HD/SD dedupe** — "BBC One" + "BBC One HD" no longer both map to one catalog id and double the listings.
- **Dropped the zone-wide cache purge** — the EPG job no longer calls `purge_everything` (which would cold-flush the whole catalog edge cache 4×/day); EPG is client-read with a short staleTime and needs no purge.
- **Fetch timeout** (AbortController) on the bundle fetch, and an array guard on `channels.json`.

### Accepted by design (documented)
- **Strict offset requirement** — an offset-less timestamp is dropped rather than guessed UTC (research-backed); any resulting regional gap is now caught by the empty-result guard.
- **`minAiring` is a runtime gate** (≥N channels currently airing), applied by the app in Phase 2 — not a build-time filter; build computes the static coverage fraction.
- **Catalog-side name collisions** resolve first-wins (inherent to best-effort name matching).
- **Last-programme null stop** — handled by Phase 2's effective-stop fallback (open-ended current programme).

## Post-Deploy Monitoring & Validation

The `v2-epg.yml` job logs a per-country coverage summary each run (`coverage gb:22% …`). After enabling: confirm a strong region (GB/US) reports non-trivial coverage; a run that logs "NOT published — degenerate" means epg.pw was unavailable (self-heals next cycle, prior guide preserved). No app/runtime change ships in this PR, so no user-facing impact yet. Rollback = revert; KV `epg:*` keys are regenerable and read only by Phase 2 code (not yet merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
