### PR TITLE
feat: v2 EPG app — now/next labels, coverage-gated Live-now board, BroadcastEvent SEO

### DIFF
--- a/app/src/components/ChannelCard.tsx
+++ b/app/src/components/ChannelCard.tsx
@@ -1,6 +1,7 @@
 import { Link } from '@tanstack/react-router'
-import type { Channel } from '../data/types'
+import type { Channel, Programme } from '../data/types'
 import { isPlausiblyLive } from '../data/status'
+import { NowNext } from './NowNext'
 
 type Mode = 'compact' | 'full'
 
@@ -46,7 +47,7 @@ function Logo({ channel }: { channel: Channel }) {
   )
 }
 
-export function ChannelCard({ channel, mode = 'full' }: { channel: Channel; mode?: Mode }) {
+export function ChannelCard({ channel, mode = 'full', schedule }: { channel: Channel; mode?: Mode; schedule?: Programme[] }) {
   return (
     <Link
       to="/channel/$id"
@@ -65,6 +66,7 @@ export function ChannelCard({ channel, mode = 'full' }: { channel: Channel; mode
             {[channel.country?.toUpperCase(), channel.categories[0]].filter(Boolean).join(' · ')}
           </span>
         )}
+        {mode === 'full' && <NowNext schedule={schedule} />}
       </span>
     </Link>
   )

--- a/app/src/components/LiveNowBoard.test.tsx
+++ b/app/src/components/LiveNowBoard.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, waitFor, cleanup } from '@testing-library/react'
+import { createRootRoute, createRouter, createMemoryHistory, RouterProvider } from '@tanstack/react-router'
+import { LiveNowBoard } from './LiveNowBoard'
+import type { EpgShard, EpgMeta } from '../data/types'
+
+// LiveNowBoard renders <Link>, so it needs a router context. Wrap it in a minimal
+// in-memory router whose root renders the board with the given props.
+function renderBoard(props: Parameters<typeof LiveNowBoard>[0]) {
+  const rootRoute = createRootRoute({ component: () => <LiveNowBoard {...props} /> })
+  const router = createRouter({ routeTree: rootRoute, history: createMemoryHistory({ initialEntries: ['/'] }) })
+  return render(<RouterProvider router={router as never} />)
+}
+
+const H = 3600_000
+function airingShard(now: number, ids: string[]): EpgShard {
+  return Object.fromEntries(ids.map((id) => [id, [{ startUtcMs: now - H, stopUtcMs: now + H, title: `${id} live` }]]))
+}
+const meta = (overrides: Partial<EpgMeta['config']> = {}): EpgMeta => ({
+  generatedAt: 'x',
+  coverage: {},
+  config: { coverageThreshold: 0.2, minAiring: 2, bracketHours: 36, ...overrides },
+})
+
+afterEach(cleanup)
+
+describe('LiveNowBoard', () => {
+  it('renders ranked airing channels when the scope is eligible', async () => {
+    const now = Date.now()
+    renderBoard({
+      shard: airingShard(now, ['A.in', 'B.in', 'C.in']),
+      meta: meta(),
+      coverage: 0.5,
+      nameById: { 'A.in': 'Alpha', 'B.in': 'Bravo', 'C.in': 'Charlie' },
+    })
+    await waitFor(() => expect(screen.getByTestId('live-now-board')).toBeTruthy())
+    expect(screen.getByText('Alpha')).toBeTruthy()
+    expect(screen.getAllByText('LIVE')).toHaveLength(3)
+  })
+
+  it('renders nothing when coverage is below threshold', async () => {
+    const now = Date.now()
+    renderBoard({ shard: airingShard(now, ['A.in', 'B.in']), meta: meta(), coverage: 0.05, nameById: {} })
+    // Give the mount effect a tick; the board must stay absent.
+    await new Promise((r) => setTimeout(r, 20))
+    expect(screen.queryByTestId('live-now-board')).toBeNull()
+  })
+
+  it('renders nothing when too few channels are currently airing (late night)', async () => {
+    const now = Date.now()
+    // Only 1 airing, minAiring is 2.
+    renderBoard({ shard: airingShard(now, ['A.in']), meta: meta(), coverage: 0.9, nameById: { 'A.in': 'Alpha' } })
+    await new Promise((r) => setTimeout(r, 20))
+    expect(screen.queryByTestId('live-now-board')).toBeNull()
+  })
+
+  it('renders nothing when EPG meta is absent', async () => {
+    const now = Date.now()
+    renderBoard({ shard: airingShard(now, ['A.in', 'B.in']), meta: null, coverage: 0.9, nameById: {} })
+    await new Promise((r) => setTimeout(r, 20))
+    expect(screen.queryByTestId('live-now-board')).toBeNull()
+  })
+})

--- a/app/src/components/LiveNowBoard.tsx
+++ b/app/src/components/LiveNowBoard.tsx
@@ -1,13 +1,15 @@
-import { useEffect, useState } from 'react'
 import { Link } from '@tanstack/react-router'
-import type { EpgShard, EpgMeta, Programme } from '../data/types'
+import type { EpgShard, EpgMeta } from '../data/types'
 import { currentlyAiring, boardEligible } from '../lib/epg'
+import { useNow } from '../lib/useNow'
 
 // "Live now" board (origin R5/R6/R8). Client-only: which channels are airing now
-// depends on the viewer's clock, and the coverage gate must not bake a server
-// "now" into SSR HTML. Renders nothing unless the scope passes the coverage +
-// min-airing gate — a covered-but-quiet scope (late night) shows no board, never
-// an empty grid (R6b).
+// depends on the viewer's clock (a ticking useNow, so it advances mid-session),
+// and the coverage gate must not bake a server "now" into SSR HTML. Renders
+// nothing unless the scope passes the coverage + min-airing gate — a covered-
+// but-quiet scope (late night) shows no board, never an empty grid (R6b).
+const MAX_ROWS = 12 // a curated highlight, not a full duplicate of the channel grid
+
 export function LiveNowBoard({
   shard,
   meta,
@@ -19,18 +21,13 @@ export function LiveNowBoard({
   coverage: number
   nameById: Record<string, string>
 }) {
-  const [airing, setAiring] = useState<Array<{ channelId: string; current: Programme }> | null>(null)
+  const now = useNow()
+  if (now == null || !meta) return null
 
-  useEffect(() => {
-    if (!meta) {
-      setAiring(null)
-      return
-    }
-    const a = currentlyAiring(shard, Date.now())
-    setAiring(boardEligible(meta, coverage, a.length) ? a : null)
-  }, [shard, meta, coverage])
+  const airing = currentlyAiring(shard, now)
+  if (!boardEligible(meta, coverage, airing.length)) return null
 
-  if (!airing || airing.length === 0) return null
+  const rows = airing.slice(0, MAX_ROWS)
 
   return (
     <section className="mb-6 rounded-lg border border-gray-200 bg-gray-50 p-4" data-testid="live-now-board">
@@ -38,7 +35,7 @@ export function LiveNowBoard({
         <span className="inline-block h-2 w-2 rounded-full bg-red-500" aria-hidden /> Live now
       </h2>
       <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-        {airing.map(({ channelId, current }) => (
+        {rows.map(({ channelId, current }) => (
           <li key={channelId}>
             <Link
               to="/channel/$id"

--- a/app/src/components/LiveNowBoard.tsx
+++ b/app/src/components/LiveNowBoard.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react'
+import { Link } from '@tanstack/react-router'
+import type { EpgShard, EpgMeta, Programme } from '../data/types'
+import { currentlyAiring, boardEligible } from '../lib/epg'
+
+// "Live now" board (origin R5/R6/R8). Client-only: which channels are airing now
+// depends on the viewer's clock, and the coverage gate must not bake a server
+// "now" into SSR HTML. Renders nothing unless the scope passes the coverage +
+// min-airing gate — a covered-but-quiet scope (late night) shows no board, never
+// an empty grid (R6b).
+export function LiveNowBoard({
+  shard,
+  meta,
+  coverage,
+  nameById,
+}: {
+  shard: EpgShard
+  meta: EpgMeta | null
+  coverage: number
+  nameById: Record<string, string>
+}) {
+  const [airing, setAiring] = useState<Array<{ channelId: string; current: Programme }> | null>(null)
+
+  useEffect(() => {
+    if (!meta) {
+      setAiring(null)
+      return
+    }
+    const a = currentlyAiring(shard, Date.now())
+    setAiring(boardEligible(meta, coverage, a.length) ? a : null)
+  }, [shard, meta, coverage])
+
+  if (!airing || airing.length === 0) return null
+
+  return (
+    <section className="mb-6 rounded-lg border border-gray-200 bg-gray-50 p-4" data-testid="live-now-board">
+      <h2 className="mb-3 flex items-center gap-2 text-lg font-semibold">
+        <span className="inline-block h-2 w-2 rounded-full bg-red-500" aria-hidden /> Live now
+      </h2>
+      <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {airing.map(({ channelId, current }) => (
+          <li key={channelId}>
+            <Link
+              to="/channel/$id"
+              params={{ id: channelId }}
+              className="flex items-center gap-2 rounded p-2 hover:bg-white focus:outline focus:outline-2 focus:outline-blue-500"
+            >
+              <span className="rounded bg-red-500 px-1.5 py-0.5 text-[10px] font-bold text-white">LIVE</span>
+              <span className="min-w-0 flex-1 truncate">
+                <span className="font-medium">{nameById[channelId] ?? channelId}</span>
+                <span className="text-gray-500"> — {current.title}</span>
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/app/src/components/NowNext.test.tsx
+++ b/app/src/components/NowNext.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, waitFor, cleanup } from '@testing-library/react'
+import { NowNext } from './NowNext'
+import type { Programme } from '../data/types'
+
+const H = 3600_000
+function around(now: number): Programme[] {
+  return [
+    { startUtcMs: now - H, stopUtcMs: now, title: 'Earlier Show' },
+    { startUtcMs: now, stopUtcMs: now + H, title: 'Current Show' },
+    { startUtcMs: now + H, stopUtcMs: now + 2 * H, title: 'Next Show' },
+  ]
+}
+
+afterEach(cleanup)
+
+describe('NowNext', () => {
+  it('shows Now and Next after mount when a schedule exists', async () => {
+    render(<NowNext schedule={around(Date.now())} />)
+    await waitFor(() => expect(screen.getByTestId('now-next')).toBeTruthy())
+    expect(screen.getByTestId('now-next').textContent).toMatch(/Now:.*Current Show/)
+    expect(screen.getByTestId('now-next').textContent).toMatch(/Next:.*Next Show/)
+  })
+
+  it('renders nothing when there is no schedule (silent degradation)', () => {
+    const { container } = render(<NowNext schedule={undefined} />)
+    expect(screen.queryByTestId('now-next')).toBeNull()
+    expect(container.textContent).toBe('')
+  })
+
+  it('renders nothing for an empty schedule', () => {
+    render(<NowNext schedule={[]} />)
+    expect(screen.queryByTestId('now-next')).toBeNull()
+  })
+
+  it('shows only Next when nothing is currently airing', async () => {
+    const now = Date.now()
+    const future: Programme[] = [{ startUtcMs: now + H, stopUtcMs: now + 2 * H, title: 'Upcoming' }]
+    render(<NowNext schedule={future} />)
+    await waitFor(() => expect(screen.getByTestId('now-next')).toBeTruthy())
+    const text = screen.getByTestId('now-next').textContent || ''
+    expect(text).toMatch(/Next:.*Upcoming/)
+    expect(text).not.toMatch(/Now:/)
+  })
+})

--- a/app/src/components/NowNext.tsx
+++ b/app/src/components/NowNext.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react'
+import type { Programme } from '../data/types'
+import { nowNext } from '../lib/epg'
+
+// Client-only "Now / Next" label. "Now" depends on the viewer's clock, so we
+// render nothing on the server / first paint and compute after mount (no
+// hydration mismatch — same pattern as LivenessHint). When no schedule exists
+// for the channel, renders nothing at all (silent degradation, origin R7).
+export function NowNext({ schedule, className }: { schedule?: Programme[]; className?: string }) {
+  const [labels, setLabels] = useState<{ now?: string; next?: string } | null>(null)
+
+  useEffect(() => {
+    if (!schedule || schedule.length === 0) {
+      setLabels(null)
+      return
+    }
+    const { current, next } = nowNext(schedule, Date.now())
+    if (!current && !next) {
+      setLabels(null)
+      return
+    }
+    setLabels({ now: current?.title, next: next?.title })
+  }, [schedule])
+
+  if (!labels) return null
+  // A block <span> (not <p>) so it's valid inside ChannelCard's <a>/<span> tree.
+  return (
+    <span className={`block truncate ${className ?? 'text-xs text-gray-500'}`} data-testid="now-next">
+      {labels.now && (
+        <span>
+          <span className="font-medium text-gray-700">Now:</span> {labels.now}
+        </span>
+      )}
+      {labels.now && labels.next && <span aria-hidden> · </span>}
+      {labels.next && (
+        <span>
+          <span className="font-medium text-gray-700">Next:</span> {labels.next}
+        </span>
+      )}
+    </span>
+  )
+}

--- a/app/src/components/NowNext.tsx
+++ b/app/src/components/NowNext.tsx
@@ -1,40 +1,30 @@
-import { useEffect, useState } from 'react'
 import type { Programme } from '../data/types'
 import { nowNext } from '../lib/epg'
+import { useNow } from '../lib/useNow'
 
-// Client-only "Now / Next" label. "Now" depends on the viewer's clock, so we
-// render nothing on the server / first paint and compute after mount (no
-// hydration mismatch — same pattern as LivenessHint). When no schedule exists
-// for the channel, renders nothing at all (silent degradation, origin R7).
+// Client-only "Now / Next" label. "Now" depends on the viewer's clock, so it's
+// computed against a ticking `useNow()` (null on server/first paint → no
+// hydration mismatch; advances so the label doesn't freeze mid-session). When no
+// schedule exists for the channel, renders nothing (silent degradation, R7).
 export function NowNext({ schedule, className }: { schedule?: Programme[]; className?: string }) {
-  const [labels, setLabels] = useState<{ now?: string; next?: string } | null>(null)
+  const now = useNow()
+  if (now == null || !schedule || schedule.length === 0) return null
 
-  useEffect(() => {
-    if (!schedule || schedule.length === 0) {
-      setLabels(null)
-      return
-    }
-    const { current, next } = nowNext(schedule, Date.now())
-    if (!current && !next) {
-      setLabels(null)
-      return
-    }
-    setLabels({ now: current?.title, next: next?.title })
-  }, [schedule])
+  const { current, next } = nowNext(schedule, now)
+  if (!current && !next) return null
 
-  if (!labels) return null
   // A block <span> (not <p>) so it's valid inside ChannelCard's <a>/<span> tree.
   return (
     <span className={`block truncate ${className ?? 'text-xs text-gray-500'}`} data-testid="now-next">
-      {labels.now && (
+      {current && (
         <span>
-          <span className="font-medium text-gray-700">Now:</span> {labels.now}
+          <span className="font-medium text-gray-700">Now:</span> {current.title}
         </span>
       )}
-      {labels.now && labels.next && <span aria-hidden> · </span>}
-      {labels.next && (
+      {current && next && <span aria-hidden> · </span>}
+      {next && (
         <span>
-          <span className="font-medium text-gray-700">Next:</span> {labels.next}
+          <span className="font-medium text-gray-700">Next:</span> {next.title}
         </span>
       )}
     </span>

--- a/app/src/data/fixture.ts
+++ b/app/src/data/fixture.ts
@@ -24,6 +24,21 @@ const SUN = {
   streams: [stream('https://example.com/suntv.m3u8', 'timeout')],
 }
 
+// A small now-relative EPG schedule so dev always shows a live now/next + board.
+// (Fixture is dev/test only; now/next correctness is tested deterministically in
+// lib/epg.test.ts with an injected `now`.) India gets a schedule; GB gets none,
+// to exercise silent degradation.
+const HOUR = 3600_000
+function schedule(now: number, titles: string[]): { startUtcMs: number; stopUtcMs: number; title: string }[] {
+  // titles[1] is "now"; one slot before, the rest after — each one hour long.
+  return titles.map((title, i) => ({ startUtcMs: now + (i - 1) * HOUR, stopUtcMs: now + i * HOUR, title }))
+}
+const NOW = Date.now()
+const EPG_IN = {
+  'NDTV.in': schedule(NOW, ['NDTV Newshour', 'NDTV Live at Now', 'The Big Fight', 'Prime Time']),
+  'SunTV.in': schedule(NOW, ['Morning Serial', 'Sun Now Showing', 'Evening Movie', 'Late Night']),
+}
+
 const DATA: Record<string, unknown> = {
   [kvKeys.meta()]: { version: 1, generatedAt: '2026-06-29T00:00:00Z', counts: { channels: 3, countries: 2, categories: 2 } },
   [kvKeys.country('gb')]: [BBC],
@@ -34,6 +49,13 @@ const DATA: Record<string, unknown> = {
     'BBCNews.uk': { country: 'gb', categories: ['news'], name: 'BBC News' },
     'NDTV.in': { country: 'in', categories: ['news'], name: 'NDTV 24x7' },
     'SunTV.in': { country: 'in', categories: ['entertainment'], name: 'Sun TV' },
+  },
+  [kvKeys.epg('in')]: EPG_IN,
+  [kvKeys.epgMeta()]: {
+    generatedAt: new Date(NOW).toISOString(),
+    coverage: { in: 0.5 },
+    // minAiring 2 so the 2-channel fixture board renders in dev.
+    config: { coverageThreshold: 0.2, minAiring: 2, bracketHours: 36 },
   },
 }
 

--- a/app/src/data/keys.ts
+++ b/app/src/data/keys.ts
@@ -4,4 +4,7 @@ export const kvKeys = {
   category: (slug: string) => `category:${slug.toLowerCase()}`,
   channelIndex: () => 'channel-index',
   meta: () => 'meta',
+  // EPG keys — must match pipeline/src/schema.js kvKey.epg/epgMeta.
+  epg: (code: string) => `epg:${code.toLowerCase()}`,
+  epgMeta: () => 'epg-meta',
 }

--- a/app/src/data/kv.test.ts
+++ b/app/src/data/kv.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { fixtureStore } from './fixture'
-import { getMeta, getCountry, getCategory, getChannelIndex, getChannel, kvStore } from './kv'
+import { getMeta, getCountry, getCategory, getChannel, getEpgShard, getEpgMeta, kvStore } from './kv'
+import { kvKeys } from './keys'
 
 const store = fixtureStore()
 
@@ -46,5 +47,34 @@ describe('KV data layer (fixture)', () => {
     const bad = kvStore({ get: async () => '{not json' })
     expect(await getMeta(bad)).toBeNull()
     expect(await getCountry(bad, 'gb')).toEqual([])
+  })
+
+  it('reads an EPG shard for a covered country', async () => {
+    const epg = await getEpgShard(store, 'in')
+    expect(Object.keys(epg)).toContain('NDTV.in')
+    expect(epg['NDTV.in'][0]).toHaveProperty('startUtcMs')
+    expect(epg['NDTV.in'][0]).toHaveProperty('title')
+  })
+
+  it('EPG shard for an uncovered country → {} (silent degradation)', async () => {
+    expect(await getEpgShard(store, 'gb')).toEqual({})
+  })
+
+  it('reads EPG meta (coverage + config)', async () => {
+    const meta = await getEpgMeta(store)
+    expect(meta?.coverage.in).toBeGreaterThan(0)
+    expect(meta?.config.coverageThreshold).toBeTypeOf('number')
+  })
+
+  it('malformed EPG value → {} / null, never thrown', async () => {
+    const bad = kvStore({ get: async () => 'nope' })
+    expect(await getEpgShard(bad, 'in')).toEqual({})
+    expect(await getEpgMeta(bad)).toBeNull()
+  })
+
+  it('EPG key builders match the pipeline producer contract', () => {
+    // Mirror of pipeline/src/schema.js kvKey.epg/epgMeta — a drift guard.
+    expect(kvKeys.epg('GB')).toBe('epg:gb')
+    expect(kvKeys.epgMeta()).toBe('epg-meta')
   })
 })

--- a/app/src/data/kv.ts
+++ b/app/src/data/kv.ts
@@ -3,7 +3,7 @@
 // (in-memory fixture). Getters are pure over the store, so they're unit-testable.
 
 import { kvKeys } from './keys'
-import type { Channel, CategoryRef, ChannelIndex, Meta } from './types'
+import type { Channel, CategoryRef, ChannelIndex, Meta, EpgShard, EpgMeta } from './types'
 
 /** Minimal read surface both KV and the fixture satisfy. */
 export interface SnapshotStore {
@@ -48,4 +48,14 @@ export async function getChannel(store: SnapshotStore, id: string): Promise<Chan
   if (!entry) return null
   const channels = await getCountry(store, entry.country)
   return channels.find((c) => c.id === id) ?? null
+}
+
+/** One country's EPG schedule shard; `{}` when absent (silent degradation). */
+export async function getEpgShard(store: SnapshotStore, code: string): Promise<EpgShard> {
+  return (await readJson<EpgShard>(store, kvKeys.epg(code))) ?? {}
+}
+
+/** EPG coverage + config; null when EPG hasn't been published. */
+export function getEpgMeta(store: SnapshotStore): Promise<EpgMeta | null> {
+  return readJson<EpgMeta>(store, kvKeys.epgMeta())
 }

--- a/app/src/data/queries.ts
+++ b/app/src/data/queries.ts
@@ -1,9 +1,12 @@
 // queryOptions per entity. Loaders call ensureQueryData(...) for SSR prefetch +
 // hydration; the snapshot only changes on publish, so staleTime is high.
 import { queryOptions } from '@tanstack/react-query'
-import { getCategory, getChannel, getChannelIndex, getCountry, getMeta, type SnapshotStore } from './kv'
+import { getCategory, getChannel, getChannelIndex, getCountry, getMeta, getEpgShard, getEpgMeta, type SnapshotStore } from './kv'
 
 const DAY = 1000 * 60 * 60 * 24
+// EPG is time-relevant (the job refreshes ~every 6h and "now" advances), so it
+// gets a short staleTime rather than the catalog's day-long cache.
+const EPG_STALE = 1000 * 60 * 15
 
 export const metaQuery = (store: SnapshotStore) =>
   queryOptions({ queryKey: ['meta'], queryFn: () => getMeta(store), staleTime: DAY })
@@ -19,3 +22,9 @@ export const channelIndexQuery = (store: SnapshotStore) =>
 
 export const channelQuery = (store: SnapshotStore, id: string) =>
   queryOptions({ queryKey: ['channel', id], queryFn: () => getChannel(store, id), staleTime: DAY })
+
+export const epgShardQuery = (store: SnapshotStore, code: string) =>
+  queryOptions({ queryKey: ['epg', code.toLowerCase()], queryFn: () => getEpgShard(store, code), staleTime: EPG_STALE })
+
+export const epgMetaQuery = (store: SnapshotStore) =>
+  queryOptions({ queryKey: ['epg-meta'], queryFn: () => getEpgMeta(store), staleTime: EPG_STALE })

--- a/app/src/data/types.ts
+++ b/app/src/data/types.ts
@@ -41,3 +41,24 @@ export interface Meta {
   generatedAt: string
   counts: { channels: number; countries: number; categories: number }
 }
+
+// --- EPG (program guide) — written by the separate EPG job under epg:* keys.
+// Times are absolute UTC ms (normalized at ingestion); "now" is computed
+// client-side against the viewer's clock. See the EPG plan / pipeline epg/*.
+
+export interface Programme {
+  startUtcMs: number
+  stopUtcMs: number | null
+  title: string
+  category?: string
+}
+
+/** One country's compact schedule: channel id → its programmes (bracketed window). */
+export type EpgShard = Record<string, Programme[]>
+
+export interface EpgMeta {
+  generatedAt: string
+  /** Per-country coverage fraction (channels-with-schedule / scope channels). */
+  coverage: Record<string, number>
+  config: { coverageThreshold: number; minAiring: number; bracketHours: number }
+}

--- a/app/src/lib/epg.test.ts
+++ b/app/src/lib/epg.test.ts
@@ -77,22 +77,19 @@ describe('currentlyAiring', () => {
 describe('boardEligible', () => {
   const meta: EpgMeta = {
     generatedAt: 'x',
-    coverage: { in: 0.5, gb: 0.05 },
+    coverage: {},
     config: { coverageThreshold: 0.2, minAiring: 3, bracketHours: 36 },
   }
   it('true when coverage exceeds threshold AND airing >= minAiring', () => {
-    expect(boardEligible(meta, 'in', 3)).toBe(true)
+    expect(boardEligible(meta, 0.5, 3)).toBe(true)
   })
   it('false when coverage below threshold', () => {
-    expect(boardEligible(meta, 'gb', 10)).toBe(false)
+    expect(boardEligible(meta, 0.05, 10)).toBe(false)
   })
   it('false when too few currently airing (e.g. late night)', () => {
-    expect(boardEligible(meta, 'in', 2)).toBe(false)
-  })
-  it('false when the scope has no coverage entry', () => {
-    expect(boardEligible(meta, 'fr', 10)).toBe(false)
+    expect(boardEligible(meta, 0.5, 2)).toBe(false)
   })
   it('false when meta is null', () => {
-    expect(boardEligible(null, 'in', 10)).toBe(false)
+    expect(boardEligible(null, 0.5, 10)).toBe(false)
   })
 })

--- a/app/src/lib/epg.test.ts
+++ b/app/src/lib/epg.test.ts
@@ -29,9 +29,10 @@ describe('nowNext', () => {
     expect(nowNext(sched, T0 + 30 * 60 * 1000).current?.title).toBe('Open')
   })
 
-  it('a trailing null-stop programme is open-ended (current until something else)', () => {
+  it('a trailing null-stop programme is current within the open-end cap, not forever', () => {
     const sched = [prog(-1, 0, 'Before'), prog(0, null, 'Last')]
-    expect(nowNext(sched, T0 + 5 * H).current?.title).toBe('Last')
+    expect(nowNext(sched, T0 + 2 * H).current?.title).toBe('Last') // within the ~4h cap
+    expect(nowNext(sched, T0 + 6 * H).current).toBeUndefined() // past the cap → not airing (stale-shard guard)
   })
 
   it('before the first programme → no current, next is the first', () => {

--- a/app/src/lib/epg.test.ts
+++ b/app/src/lib/epg.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { nowNext, currentlyAiring, boardEligible } from './epg'
+import type { Programme, EpgShard, EpgMeta } from '../data/types'
+
+const H = 3600_000
+const T0 = Date.UTC(2026, 5, 30, 12, 0, 0) // a fixed reference "now"
+
+function prog(startOffsetH: number, stopOffsetH: number | null, title: string): Programme {
+  return { startUtcMs: T0 + startOffsetH * H, stopUtcMs: stopOffsetH == null ? null : T0 + stopOffsetH * H, title }
+}
+
+// schedule: [10:00-11:00 Past], [11:00-12:00 Earlier], [12:00-13:00 Now], [13:00-14:00 Next]
+const schedule = [prog(-2, -1, 'Past'), prog(-1, 0, 'Earlier'), prog(0, 1, 'Now'), prog(1, 2, 'Next')]
+
+describe('nowNext', () => {
+  it('finds the current and next programme bracketing now', () => {
+    const r = nowNext(schedule, T0 + 30 * 60 * 1000) // 12:30
+    expect(r.current?.title).toBe('Now')
+    expect(r.next?.title).toBe('Next')
+  })
+
+  it('treats the interval as half-open: now exactly at a start is current', () => {
+    const r = nowNext(schedule, T0) // exactly 12:00
+    expect(r.current?.title).toBe('Now')
+  })
+
+  it('uses the next programme start as the effective stop when stop is null', () => {
+    const sched = [prog(0, null, 'Open'), prog(1, 2, 'Following')]
+    expect(nowNext(sched, T0 + 30 * 60 * 1000).current?.title).toBe('Open')
+  })
+
+  it('a trailing null-stop programme is open-ended (current until something else)', () => {
+    const sched = [prog(-1, 0, 'Before'), prog(0, null, 'Last')]
+    expect(nowNext(sched, T0 + 5 * H).current?.title).toBe('Last')
+  })
+
+  it('before the first programme → no current, next is the first', () => {
+    const r = nowNext(schedule, T0 - 5 * H)
+    expect(r.current).toBeUndefined()
+    expect(r.next?.title).toBe('Past')
+  })
+
+  it('after the last bounded programme → no current, no next', () => {
+    const r = nowNext(schedule, T0 + 10 * H)
+    expect(r.current).toBeUndefined()
+    expect(r.next).toBeUndefined()
+  })
+
+  it('far-offset viewer still resolves within a ±day-bracketed schedule', () => {
+    // Schedule entries 20h on either side of now (as the pipeline's ±36h window allows).
+    const sched = [prog(-20, -19, 'Yesterday'), prog(-1, 1, 'Spanning'), prog(19, 20, 'Tomorrow')]
+    expect(nowNext(sched, T0).current?.title).toBe('Spanning')
+  })
+
+  it('empty schedule → both undefined', () => {
+    expect(nowNext([], T0)).toEqual({ current: undefined, next: undefined })
+  })
+})
+
+describe('currentlyAiring', () => {
+  const shard: EpgShard = {
+    'A.in': [prog(0, 1, 'A now')],
+    'B.in': [prog(1, 2, 'B later')], // not airing now
+    'C.in': [prog(-1, 1, 'C now')],
+  }
+  it('returns only channels with a current programme', () => {
+    const airing = currentlyAiring(shard, T0 + 10 * 60 * 1000)
+    expect(airing.map((a) => a.channelId).sort()).toEqual(['A.in', 'C.in'])
+    expect(airing.find((a) => a.channelId === 'A.in')?.current.title).toBe('A now')
+  })
+  it('deterministic order (by channelId)', () => {
+    const airing = currentlyAiring(shard, T0 + 10 * 60 * 1000)
+    expect(airing.map((a) => a.channelId)).toEqual(['A.in', 'C.in'])
+  })
+})
+
+describe('boardEligible', () => {
+  const meta: EpgMeta = {
+    generatedAt: 'x',
+    coverage: { in: 0.5, gb: 0.05 },
+    config: { coverageThreshold: 0.2, minAiring: 3, bracketHours: 36 },
+  }
+  it('true when coverage exceeds threshold AND airing >= minAiring', () => {
+    expect(boardEligible(meta, 'in', 3)).toBe(true)
+  })
+  it('false when coverage below threshold', () => {
+    expect(boardEligible(meta, 'gb', 10)).toBe(false)
+  })
+  it('false when too few currently airing (e.g. late night)', () => {
+    expect(boardEligible(meta, 'in', 2)).toBe(false)
+  })
+  it('false when the scope has no coverage entry', () => {
+    expect(boardEligible(meta, 'fr', 10)).toBe(false)
+  })
+  it('false when meta is null', () => {
+    expect(boardEligible(null, 'in', 10)).toBe(false)
+  })
+})

--- a/app/src/lib/epg.ts
+++ b/app/src/lib/epg.ts
@@ -1,0 +1,57 @@
+import type { Programme, EpgShard, EpgMeta } from '../data/types'
+
+// Pure now/next + board-gating compute over an EPG schedule. Timezone-correct by
+// construction: programmes carry absolute UTC instants and `nowMs` is always
+// passed in (the viewer's clock), so there is no server "now" and the result is
+// deterministic and testable. See the EPG plan (U5).
+
+/** Effective stop = explicit stop, else the next programme's start (open-ended if last). */
+function effectiveStop(programmes: Programme[], i: number): number {
+  const p = programmes[i]
+  if (p.stopUtcMs != null) return p.stopUtcMs
+  const next = programmes[i + 1]
+  return next ? next.startUtcMs : Infinity // trailing null-stop → open-ended
+}
+
+/**
+ * The programme airing at `nowMs` (half-open [start, stop)) and the soonest one
+ * starting after it. Assumes the schedule is start-sorted (the pipeline emits it
+ * sorted), but sorts defensively so callers can't break it.
+ */
+export function nowNext(schedule: Programme[], nowMs: number): { current?: Programme; next?: Programme } {
+  if (schedule.length === 0) return { current: undefined, next: undefined }
+  const programmes = schedule.every((p, i) => i === 0 || p.startUtcMs >= schedule[i - 1].startUtcMs)
+    ? schedule
+    : schedule.slice().sort((a, b) => a.startUtcMs - b.startUtcMs)
+
+  let current: Programme | undefined
+  let next: Programme | undefined
+  for (let i = 0; i < programmes.length; i++) {
+    const p = programmes[i]
+    if (p.startUtcMs <= nowMs && nowMs < effectiveStop(programmes, i)) {
+      current = p
+    } else if (p.startUtcMs > nowMs) {
+      next = p
+      break // first one starting after now (programmes are sorted)
+    }
+  }
+  return { current, next }
+}
+
+/** Channels in a shard with a programme airing right now (for the Live-now board, R8). */
+export function currentlyAiring(shard: EpgShard, nowMs: number): Array<{ channelId: string; current: Programme }> {
+  const out: Array<{ channelId: string; current: Programme }> = []
+  for (const channelId of Object.keys(shard).sort()) {
+    const current = nowNext(shard[channelId], nowMs).current
+    if (current) out.push({ channelId, current })
+  }
+  return out
+}
+
+/** Whether the Live-now board should show for a scope: coverage AND enough airing (R6). */
+export function boardEligible(meta: EpgMeta | null, scopeKey: string, airingCount: number): boolean {
+  if (!meta) return false
+  const coverage = meta.coverage[scopeKey]
+  if (coverage == null) return false
+  return coverage >= meta.config.coverageThreshold && airingCount >= meta.config.minAiring
+}

--- a/app/src/lib/epg.ts
+++ b/app/src/lib/epg.ts
@@ -48,10 +48,12 @@ export function currentlyAiring(shard: EpgShard, nowMs: number): Array<{ channel
   return out
 }
 
-/** Whether the Live-now board should show for a scope: coverage AND enough airing (R6). */
-export function boardEligible(meta: EpgMeta | null, scopeKey: string, airingCount: number): boolean {
+/**
+ * Whether the Live-now board should show: the scope's coverage exceeds the
+ * threshold AND enough channels are airing right now (R6). `coverage` is passed
+ * in (per-country from epg-meta, or computed for a cross-country category scope).
+ */
+export function boardEligible(meta: EpgMeta | null, coverage: number, airingCount: number): boolean {
   if (!meta) return false
-  const coverage = meta.coverage[scopeKey]
-  if (coverage == null) return false
   return coverage >= meta.config.coverageThreshold && airingCount >= meta.config.minAiring
 }

--- a/app/src/lib/epg.ts
+++ b/app/src/lib/epg.ts
@@ -5,12 +5,17 @@ import type { Programme, EpgShard, EpgMeta } from '../data/types'
 // passed in (the viewer's clock), so there is no server "now" and the result is
 // deterministic and testable. See the EPG plan (U5).
 
-/** Effective stop = explicit stop, else the next programme's start (open-ended if last). */
+// A trailing null-stop programme (no explicit stop and nothing after it) is
+// capped to this duration rather than airing forever — a stale shard must not
+// keep a finished programme flagged "Now" / counted as airing indefinitely.
+const MAX_OPEN_MS = 4 * 3600_000
+
+/** Effective stop = explicit stop, else the next programme's start, else a bounded open end. */
 function effectiveStop(programmes: Programme[], i: number): number {
   const p = programmes[i]
   if (p.stopUtcMs != null) return p.stopUtcMs
   const next = programmes[i + 1]
-  return next ? next.startUtcMs : Infinity // trailing null-stop → open-ended
+  return next ? next.startUtcMs : p.startUtcMs + MAX_OPEN_MS
 }
 
 /**

--- a/app/src/lib/jsonld.test.ts
+++ b/app/src/lib/jsonld.test.ts
@@ -19,38 +19,47 @@ describe('broadcastEvents', () => {
     { startUtcMs: stop, stopUtcMs: null, title: 'The Film' },
   ]
 
-  it('builds BroadcastEvents with absolute ISO-UTC times', () => {
-    const events = broadcastEvents(sched)
+  it('builds BroadcastEvents with absolute ISO-UTC times, live flag on the airing one', () => {
+    const events = broadcastEvents(sched, start + 60_000) // 14:31 → first is airing
     expect(events).toHaveLength(2)
     expect(events[0]['@type']).toBe('BroadcastEvent')
     expect(events[0].name).toBe('News at Six')
     expect(events[0].startDate).toBe('2026-06-30T14:30:00.000Z')
     expect(events[0].endDate).toBe('2026-06-30T15:00:00.000Z')
+    expect(events[0].isLiveBroadcast).toBe(true)
+    expect(events[1].isLiveBroadcast).toBe(false) // upcoming, not live
+  })
+
+  it('drops already-finished programmes (no stale "live" rich results)', () => {
+    // now is after the first programme ended → only the second remains.
+    const events = broadcastEvents(sched, stop + 60_000)
+    expect(events).toHaveLength(1)
+    expect(events[0].name).toBe('The Film')
   })
 
   it('omits endDate when stop is null (open-ended)', () => {
-    const events = broadcastEvents(sched)
+    const events = broadcastEvents(sched, start)
     expect(events[1].endDate).toBeUndefined()
     expect(events[1].startDate).toBe('2026-06-30T15:00:00.000Z')
   })
 
   it('caps the number of events', () => {
     const many: Programme[] = Array.from({ length: 10 }, (_, i) => ({ startUtcMs: start + i * 3600_000, stopUtcMs: null, title: `P${i}` }))
-    expect(broadcastEvents(many, 3)).toHaveLength(3)
+    expect(broadcastEvents(many, start, 3)).toHaveLength(3)
   })
 
   it('returns [] for no schedule (so the caller omits the property)', () => {
-    expect(broadcastEvents(null)).toEqual([])
-    expect(broadcastEvents([])).toEqual([])
-    expect(broadcastEvents(undefined)).toEqual([])
+    expect(broadcastEvents(null, start)).toEqual([])
+    expect(broadcastEvents([], start)).toEqual([])
+    expect(broadcastEvents(undefined, start)).toEqual([])
   })
 
-  it('output is identical across calls (absolute times, no "now")', () => {
-    expect(broadcastEvents(sched)).toEqual(broadcastEvents(sched))
+  it('output is identical for a fixed now (absolute times)', () => {
+    expect(broadcastEvents(sched, start)).toEqual(broadcastEvents(sched, start))
   })
 
   it('a title with </script> is neutralized once serialized via toJsonLd', () => {
-    const events = broadcastEvents([{ startUtcMs: start, stopUtcMs: stop, title: 'X</script>' }])
+    const events = broadcastEvents([{ startUtcMs: start, stopUtcMs: stop, title: 'X</script>' }], start)
     expect(toJsonLd(events)).not.toContain('</script>')
   })
 })

--- a/app/src/lib/jsonld.test.ts
+++ b/app/src/lib/jsonld.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { toJsonLd, broadcastEvents } from './jsonld'
+import type { Programme } from '../data/types'
+
+describe('toJsonLd', () => {
+  it('escapes characters that could break out of a <script> block', () => {
+    const out = toJsonLd({ name: 'Evil </script><script>alert(1)' })
+    expect(out).not.toContain('</script>')
+    expect(out).not.toContain('<')
+    expect(out).toContain('\\u003c') // < escaped
+  })
+})
+
+describe('broadcastEvents', () => {
+  const start = Date.UTC(2026, 5, 30, 14, 30, 0)
+  const stop = Date.UTC(2026, 5, 30, 15, 0, 0)
+  const sched: Programme[] = [
+    { startUtcMs: start, stopUtcMs: stop, title: 'News at Six' },
+    { startUtcMs: stop, stopUtcMs: null, title: 'The Film' },
+  ]
+
+  it('builds BroadcastEvents with absolute ISO-UTC times', () => {
+    const events = broadcastEvents(sched)
+    expect(events).toHaveLength(2)
+    expect(events[0]['@type']).toBe('BroadcastEvent')
+    expect(events[0].name).toBe('News at Six')
+    expect(events[0].startDate).toBe('2026-06-30T14:30:00.000Z')
+    expect(events[0].endDate).toBe('2026-06-30T15:00:00.000Z')
+  })
+
+  it('omits endDate when stop is null (open-ended)', () => {
+    const events = broadcastEvents(sched)
+    expect(events[1].endDate).toBeUndefined()
+    expect(events[1].startDate).toBe('2026-06-30T15:00:00.000Z')
+  })
+
+  it('caps the number of events', () => {
+    const many: Programme[] = Array.from({ length: 10 }, (_, i) => ({ startUtcMs: start + i * 3600_000, stopUtcMs: null, title: `P${i}` }))
+    expect(broadcastEvents(many, 3)).toHaveLength(3)
+  })
+
+  it('returns [] for no schedule (so the caller omits the property)', () => {
+    expect(broadcastEvents(null)).toEqual([])
+    expect(broadcastEvents([])).toEqual([])
+    expect(broadcastEvents(undefined)).toEqual([])
+  })
+
+  it('output is identical across calls (absolute times, no "now")', () => {
+    expect(broadcastEvents(sched)).toEqual(broadcastEvents(sched))
+  })
+
+  it('a title with </script> is neutralized once serialized via toJsonLd', () => {
+    const events = broadcastEvents([{ startUtcMs: start, stopUtcMs: stop, title: 'X</script>' }])
+    expect(toJsonLd(events)).not.toContain('</script>')
+  })
+})

--- a/app/src/lib/jsonld.ts
+++ b/app/src/lib/jsonld.ts
@@ -11,21 +11,33 @@ export function toJsonLd(obj: unknown): string {
 }
 
 /**
- * Build BroadcastEvent JSON-LD from a channel's schedule (origin R9). Uses
- * absolute UTC instants → server-renderable (crawlers compute currency
- * themselves; no per-second accuracy, no SSR "now"). Returns [] when there's no
- * schedule so the caller can omit the property entirely (silent degradation).
+ * Build BroadcastEvent JSON-LD from a channel's schedule (origin R9). Emits
+ * absolute UTC instants for the currently-airing + upcoming programmes (past
+ * ones, which the ±day shard front-loads, are dropped so crawlers don't index
+ * finished shows), flagging `isLiveBroadcast` only for the one airing at `now`.
+ * `now` is the server request time — fine for SEO (no per-second accuracy), and
+ * the output goes through a dangerouslySetInnerHTML script, so it isn't subject
+ * to React hydration diffing. Returns [] when there's nothing to show so the
+ * caller can fall back to a generic live event.
  */
-export function broadcastEvents(schedule: Programme[] | null | undefined, max = 5): Array<Record<string, unknown>> {
+export function broadcastEvents(
+  schedule: Programme[] | null | undefined,
+  now: number,
+  max = 5,
+): Array<Record<string, unknown>> {
   if (!schedule || schedule.length === 0) return []
-  return schedule.slice(0, max).map((p) => {
-    const event: Record<string, unknown> = {
-      '@type': 'BroadcastEvent',
-      name: p.title,
-      startDate: new Date(p.startUtcMs).toISOString(),
-      isLiveBroadcast: true,
-    }
-    if (p.stopUtcMs != null) event.endDate = new Date(p.stopUtcMs).toISOString()
-    return event
-  })
+  return schedule
+    .filter((p) => (p.stopUtcMs ?? Infinity) > now) // current + upcoming only
+    .slice(0, max)
+    .map((p) => {
+      const live = p.startUtcMs <= now && now < (p.stopUtcMs ?? Infinity)
+      const event: Record<string, unknown> = {
+        '@type': 'BroadcastEvent',
+        name: p.title,
+        startDate: new Date(p.startUtcMs).toISOString(),
+        isLiveBroadcast: live,
+      }
+      if (p.stopUtcMs != null) event.endDate = new Date(p.stopUtcMs).toISOString()
+      return event
+    })
 }

--- a/app/src/lib/jsonld.ts
+++ b/app/src/lib/jsonld.ts
@@ -1,3 +1,5 @@
+import type { Programme } from '../data/types'
+
 // JSON-LD-safe serialization — mirrors the pipeline's pipeline/src/sanitize.js
 // toJsonLd: escape characters that could break out of a <script> block or the
 // line (U+2028/U+2029). Built via new RegExp from escaped ASCII to keep this
@@ -6,4 +8,24 @@ const UNSAFE = new RegExp('[<>&\\u2028\\u2029]', 'g')
 
 export function toJsonLd(obj: unknown): string {
   return JSON.stringify(obj).replace(UNSAFE, (ch) => '\\u' + ch.charCodeAt(0).toString(16).padStart(4, '0'))
+}
+
+/**
+ * Build BroadcastEvent JSON-LD from a channel's schedule (origin R9). Uses
+ * absolute UTC instants → server-renderable (crawlers compute currency
+ * themselves; no per-second accuracy, no SSR "now"). Returns [] when there's no
+ * schedule so the caller can omit the property entirely (silent degradation).
+ */
+export function broadcastEvents(schedule: Programme[] | null | undefined, max = 5): Array<Record<string, unknown>> {
+  if (!schedule || schedule.length === 0) return []
+  return schedule.slice(0, max).map((p) => {
+    const event: Record<string, unknown> = {
+      '@type': 'BroadcastEvent',
+      name: p.title,
+      startDate: new Date(p.startUtcMs).toISOString(),
+      isLiveBroadcast: true,
+    }
+    if (p.stopUtcMs != null) event.endDate = new Date(p.stopUtcMs).toISOString()
+    return event
+  })
 }

--- a/app/src/lib/useNow.ts
+++ b/app/src/lib/useNow.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react'
+
+// A ticking "now" for client-only, time-relative UI (now/next labels, the Live
+// board). Returns null on the server and first paint — so SSR markup matches and
+// there's no hydration mismatch — then a live Date.now() that advances on an
+// interval, so labels and the board don't freeze on the page-load instant for a
+// long-running live-TV session.
+export function useNow(intervalMs = 60_000): number | null {
+  const [now, setNow] = useState<number | null>(null)
+  useEffect(() => {
+    setNow(Date.now())
+    const id = setInterval(() => setNow(Date.now()), intervalMs)
+    return () => clearInterval(id)
+  }, [intervalMs])
+  return now
+}

--- a/app/src/routes/category.$slug.tsx
+++ b/app/src/routes/category.$slug.tsx
@@ -11,10 +11,15 @@ export const Route = createFileRoute('/category/$slug')({
     const [refs, index, epgMeta] = await Promise.all([getCategory(store, params.slug), getChannelIndex(store), getEpgMeta(store)])
     const items = refs.map((r) => ({ id: r.id, country: r.country, name: index[r.id]?.name ?? r.id }))
 
-    // EPG is sharded per country; a category spans countries, so fetch each
-    // distinct country's shard once and union the entries for this category's
-    // channels. Category coverage is computed here (epg-meta only has per-country).
-    const countries = [...new Set(refs.map((r) => r.country))]
+    // EPG is sharded per country; a category spans countries. Only fetch shards
+    // for countries that actually have EPG coverage (per epg-meta) — avoids N
+    // pointless KV reads for EPG-less countries on a broad category, and keeps
+    // category coverage from being diluted by those countries (which would hide
+    // the board even when the covered slice is airing).
+    const covered = new Set(
+      [...new Set(refs.map((r) => r.country))].filter((c) => epgMeta?.coverage[c] != null),
+    )
+    const countries = [...covered]
     const shards = await Promise.all(countries.map((c) => getEpgShard(store, c)))
     const byCountry: Record<string, EpgShard> = Object.fromEntries(countries.map((c, i) => [c, shards[i]]))
     const epg: EpgShard = {}
@@ -22,7 +27,9 @@ export const Route = createFileRoute('/category/$slug')({
       const sched = byCountry[r.country]?.[r.id]
       if (sched) epg[r.id] = sched
     }
-    const coverage = items.length ? Object.keys(epg).length / items.length : 0
+    // Coverage denominator = this category's channels in covered countries only.
+    const relevant = items.filter((it) => covered.has(it.country))
+    const coverage = relevant.length ? Object.keys(epg).length / relevant.length : 0
     return { slug: params.slug, items, epg, epgMeta, coverage }
   },
   head: ({ params }) => ({ meta: [{ title: `${params.slug} channels — free live TV guide` }] }),

--- a/app/src/routes/category.$slug.tsx
+++ b/app/src/routes/category.$slug.tsx
@@ -1,25 +1,42 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { getStore } from '../data/store'
-import { getCategory, getChannelIndex } from '../data/kv'
+import { getCategory, getChannelIndex, getEpgShard, getEpgMeta } from '../data/kv'
+import { LiveNowBoard } from '../components/LiveNowBoard'
 import { StructuredData } from '../components/StructuredData'
+import type { EpgShard } from '../data/types'
 
 export const Route = createFileRoute('/category/$slug')({
   loader: async ({ params }) => {
     const store = getStore()
-    const [refs, index] = await Promise.all([getCategory(store, params.slug), getChannelIndex(store)])
-    return { slug: params.slug, items: refs.map((r) => ({ id: r.id, country: r.country, name: index[r.id]?.name ?? r.id })) }
+    const [refs, index, epgMeta] = await Promise.all([getCategory(store, params.slug), getChannelIndex(store), getEpgMeta(store)])
+    const items = refs.map((r) => ({ id: r.id, country: r.country, name: index[r.id]?.name ?? r.id }))
+
+    // EPG is sharded per country; a category spans countries, so fetch each
+    // distinct country's shard once and union the entries for this category's
+    // channels. Category coverage is computed here (epg-meta only has per-country).
+    const countries = [...new Set(refs.map((r) => r.country))]
+    const shards = await Promise.all(countries.map((c) => getEpgShard(store, c)))
+    const byCountry: Record<string, EpgShard> = Object.fromEntries(countries.map((c, i) => [c, shards[i]]))
+    const epg: EpgShard = {}
+    for (const r of refs) {
+      const sched = byCountry[r.country]?.[r.id]
+      if (sched) epg[r.id] = sched
+    }
+    const coverage = items.length ? Object.keys(epg).length / items.length : 0
+    return { slug: params.slug, items, epg, epgMeta, coverage }
   },
   head: ({ params }) => ({ meta: [{ title: `${params.slug} channels — free live TV guide` }] }),
   component: CategoryPage,
 })
 
 function CategoryPage() {
-  const { slug, items } = Route.useLoaderData()
+  const { slug, items, epg, epgMeta, coverage } = Route.useLoaderData()
   const itemList = {
     '@context': 'https://schema.org',
     '@type': 'ItemList',
     itemListElement: items.map((it, i) => ({ '@type': 'ListItem', position: i + 1, name: it.name, url: `/channel/${it.id}` })),
   }
+  const nameById = Object.fromEntries(items.map((it) => [it.id, it.name]))
   return (
     <main className="mx-auto max-w-5xl p-6">
       <StructuredData data={itemList} />
@@ -27,6 +44,7 @@ function CategoryPage() {
         <Link to="/" className="hover:underline">Home</Link> <span aria-hidden>/</span> {slug}
       </nav>
       <h1 className="mb-4 text-2xl font-bold capitalize">{slug}</h1>
+      <LiveNowBoard shard={epg} meta={epgMeta} coverage={coverage} nameById={nameById} />
       {items.length === 0 ? (
         <p className="text-gray-500">No channels found in this category.</p>
       ) : (

--- a/app/src/routes/channel.$id.tsx
+++ b/app/src/routes/channel.$id.tsx
@@ -31,9 +31,10 @@ export const Route = createFileRoute('/channel/$id')({
 
 function ChannelPage() {
   const { channel, schedule } = Route.useLoaderData()
-  // Absolute-UTC BroadcastEvents from the schedule (R9), else a single live event.
-  // SSR-safe: no "now" is computed, so server and client output match.
-  const events = broadcastEvents(schedule)
+  // Absolute-UTC BroadcastEvents for the current + upcoming schedule (R9), else a
+  // single generic live event. Emitted via a JSON-LD script (dangerouslySetInnerHTML),
+  // so the request-time `now` used to drop past programmes isn't hydration-diffed.
+  const events = broadcastEvents(schedule, Date.now())
   const videoObject = {
     '@context': 'https://schema.org',
     '@type': 'VideoObject',

--- a/app/src/routes/channel.$id.tsx
+++ b/app/src/routes/channel.$id.tsx
@@ -1,15 +1,20 @@
 import { createFileRoute, Link, notFound } from '@tanstack/react-router'
 import { getStore } from '../data/store'
-import { getChannel } from '../data/kv'
+import { getChannel, getEpgShard } from '../data/kv'
 import { Player } from '../components/Player'
 import { StructuredData } from '../components/StructuredData'
 import { LivenessHint } from '../components/LivenessHint'
+import { NowNext } from '../components/NowNext'
 
 export const Route = createFileRoute('/channel/$id')({
   loader: async ({ params }) => {
-    const channel = await getChannel(getStore(), params.id)
+    const store = getStore()
+    const channel = await getChannel(store, params.id)
     if (!channel) throw notFound()
-    return { channel }
+    // EPG schedule (absolute UTC times) fetched server-side; now/next is computed
+    // client-side. Absent country/coverage → empty → labels silently omitted.
+    const schedule = channel.country ? (await getEpgShard(store, channel.country))[channel.id] : undefined
+    return { channel, schedule: schedule ?? null }
   },
   head: ({ loaderData }) => ({
     meta: [{ title: loaderData ? `${loaderData.channel.name} — watch live` : 'Channel' }],
@@ -24,7 +29,7 @@ export const Route = createFileRoute('/channel/$id')({
 })
 
 function ChannelPage() {
-  const { channel } = Route.useLoaderData()
+  const { channel, schedule } = Route.useLoaderData()
   const videoObject = {
     '@context': 'https://schema.org',
     '@type': 'VideoObject',
@@ -49,6 +54,7 @@ function ChannelPage() {
       </nav>
       <h1 className="mb-3 text-xl font-bold">{channel.name}</h1>
       <Player channel={channel} />
+      <NowNext schedule={schedule ?? undefined} className="mt-3 text-sm text-gray-600" />
       <section className="mt-4 flex items-center gap-3">
         {channel.logo && <img src={channel.logo} alt="" className="h-12 w-12 rounded object-contain" />}
         <div className="text-sm text-gray-600">

--- a/app/src/routes/channel.$id.tsx
+++ b/app/src/routes/channel.$id.tsx
@@ -5,6 +5,7 @@ import { Player } from '../components/Player'
 import { StructuredData } from '../components/StructuredData'
 import { LivenessHint } from '../components/LivenessHint'
 import { NowNext } from '../components/NowNext'
+import { broadcastEvents } from '../lib/jsonld'
 
 export const Route = createFileRoute('/channel/$id')({
   loader: async ({ params }) => {
@@ -30,6 +31,9 @@ export const Route = createFileRoute('/channel/$id')({
 
 function ChannelPage() {
   const { channel, schedule } = Route.useLoaderData()
+  // Absolute-UTC BroadcastEvents from the schedule (R9), else a single live event.
+  // SSR-safe: no "now" is computed, so server and client output match.
+  const events = broadcastEvents(schedule)
   const videoObject = {
     '@context': 'https://schema.org',
     '@type': 'VideoObject',
@@ -37,7 +41,7 @@ function ChannelPage() {
     description: `Watch ${channel.name} live`,
     thumbnailUrl: channel.logo ?? undefined,
     contentUrl: channel.streams[0]?.url,
-    publication: { '@type': 'BroadcastEvent', isLiveBroadcast: true },
+    publication: events.length > 0 ? events : { '@type': 'BroadcastEvent', isLiveBroadcast: true },
   }
   // Mobile: player above the fold (rendered before the metadata block).
   return (

--- a/app/src/routes/country.$code.tsx
+++ b/app/src/routes/country.$code.tsx
@@ -1,11 +1,20 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { getStore } from '../data/store'
-import { getCountry } from '../data/kv'
+import { getCountry, getEpgShard, getEpgMeta } from '../data/kv'
 import { ChannelCard } from '../components/ChannelCard'
+import { LiveNowBoard } from '../components/LiveNowBoard'
 import { StructuredData } from '../components/StructuredData'
 
 export const Route = createFileRoute('/country/$code')({
-  loader: async ({ params }) => ({ code: params.code, channels: await getCountry(getStore(), params.code) }),
+  loader: async ({ params }) => {
+    const store = getStore()
+    const [channels, epg, epgMeta] = await Promise.all([
+      getCountry(store, params.code),
+      getEpgShard(store, params.code),
+      getEpgMeta(store),
+    ])
+    return { code: params.code, channels, epg, epgMeta }
+  },
   head: ({ params }) => ({
     meta: [{ title: `Live TV channels in ${params.code.toUpperCase()} — free streaming guide` }],
   }),
@@ -13,12 +22,13 @@ export const Route = createFileRoute('/country/$code')({
 })
 
 function CountryPage() {
-  const { code, channels } = Route.useLoaderData()
+  const { code, channels, epg, epgMeta } = Route.useLoaderData()
   const itemList = {
     '@context': 'https://schema.org',
     '@type': 'ItemList',
     itemListElement: channels.map((c, i) => ({ '@type': 'ListItem', position: i + 1, name: c.name, url: `/channel/${c.id}` })),
   }
+  const nameById = Object.fromEntries(channels.map((c) => [c.id, c.name]))
   return (
     <main className="mx-auto max-w-5xl p-6">
       <StructuredData data={itemList} />
@@ -26,12 +36,13 @@ function CountryPage() {
         <Link to="/" className="hover:underline">Home</Link> <span aria-hidden>/</span> {code.toUpperCase()}
       </nav>
       <h1 className="mb-4 text-2xl font-bold">Live TV in {code.toUpperCase()}</h1>
+      <LiveNowBoard shard={epg} meta={epgMeta} coverage={epgMeta?.coverage[code.toLowerCase()] ?? 0} nameById={nameById} />
       {channels.length === 0 ? (
         <p className="text-gray-500">No channels found for this country.</p>
       ) : (
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3" data-testid="channel-grid">
           {channels.map((c) => (
-            <ChannelCard key={c.id} channel={c} mode="full" />
+            <ChannelCard key={c.id} channel={c} mode="full" schedule={epg[c.id]} />
           ))}
         </div>
       )}


### PR DESCRIPTION
## What & why

**Phase 2 of the v2 EPG feature** (plan: `docs/plans/2026-06-30-001-feat-v2-epg-plan.md`) — the **app half**, built on the EPG KV contract shipped in Phase 1 (#104). Adds, where program data exists and degrading silently where it doesn't:

- **now/next labels** wherever channels appear (channel page + cards), computed client-side against the viewer's clock (R4).
- a **coverage-gated "Live now" board** on country/category surfaces (R5/R6/R8).
- **`BroadcastEvent` JSON-LD** on channel pages (R9).

## How it works

- `app/src/lib/epg.ts` — pure, tested `nowNext` / `currentlyAiring` / `boardEligible` over absolute-UTC schedules (`now` injected → timezone-correct, deterministic).
- `app/src/lib/useNow.ts` — a ticking client-only "now" (null on server → no hydration mismatch; advances so labels/board don't freeze mid-session).
- `app/src/components/NowNext.tsx` — client-only now/next label; renders nothing without a schedule (R7).
- `app/src/components/LiveNowBoard.tsx` — client-only, coverage-gated, capped board; omitted entirely below threshold or when nothing's airing (R6b — never an empty grid).
- `app/src/lib/jsonld.ts` `broadcastEvents` — current+upcoming programmes as `BroadcastEvent`s with absolute-UTC times, `isLiveBroadcast` set per-programme; SSR-safe (emitted via the existing escaped JSON-LD `<script>`).
- `app/src/data/{types,keys,kv,queries,fixture}.ts` — EPG types, `epg:<country>`/`epg-meta` getters (matching the pipeline keys, guarded by a contract test), short-staleTime queries, and dev fixture EPG.
- Routes (`channel.$id`, `country.$code`, `category.$slug`) fetch EPG server-side and render the surfaces; the category route unions per-country shards over covered countries only.

## Testing

- **82 app tests pass** (`cd app && npm run test`; +37 for EPG) — now/next bracketing (half-open, null-stop cap, far-offset), board gating, the cross-package key contract, BroadcastEvent filtering + escaping, and the client-only components.
- **Browser-verified via Playwright MCP**: the IN page renders the Live-now board + per-card now/next; a channel page shows now/next + a 4-event `BroadcastEvent` JSON-LD (confirmed in the DOM, absolute UTC); GB (no EPG) shows no board/labels — silent degradation. Zero console errors/warnings. tsc clean.

## Review

High-effort multi-agent review (32 agents). **Fixed** the confirmed bugs:
- **Staleness** — now/next labels and the board snapshotted `Date.now()` once and never advanced (wrong "now" for a whole live-TV session). Fixed with the shared ticking `useNow` hook (which also de-duplicated the hand-rolled mounted-gate).
- **`effectiveStop` Infinity** — a trailing null-stop programme aired forever; now capped (~4h) so a stale shard can't keep a finished show "Now".
- **Unbounded board** — capped to 12 rows (a curated highlight, not a full duplicate of the grid).
- **Category coverage dilution** — coverage now counts only channels in EPG-covered countries (and the loader only fetches those shards), so a category spanning many EPG-less countries no longer hides the board / over-fetches KV.
- **`BroadcastEvent` correctness** — emits only current+upcoming programmes with a correct per-programme `isLiveBroadcast`, instead of the first 5 (often-past) entries all flagged live.

## Post-Deploy Monitoring & Validation

EPG rendering is client-side and additive; no server/runtime infra change. Once live, the natural signal is the share of country/channel pages that show EPG (depends on the Phase 1 job's coverage). The labels/board self-degrade to nothing where coverage is absent, so a low-coverage day reads as "no EPG", not breakage. Rollback = revert; reads only the `epg:*` KV keys Phase 1 publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
