### PR TITLE
feat: v2 engagement (Remote Config) — kill-switch, featured rails, announcement

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -16,6 +16,7 @@
         "@tanstack/react-router-with-query": "^1.130.17",
         "@tanstack/react-start": "latest",
         "@tanstack/router-plugin": "^1.132.0",
+        "firebase": "^12.15.0",
         "hls.js": "^1.6.16",
         "lucide-react": "^0.545.0",
         "react": "^19.2.0",
@@ -1102,6 +1103,649 @@
         }
       }
     },
+    "node_modules/@firebase/ai": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.13.1.tgz",
+      "integrity": "sha512-RhT/VViTPBSplhQSuEp62HhLvfsV+LowMh8ZUo5MMRDzG7oFtSget4Kmg5oHP50hDVyWQuQj6to9iPFEZk08Tw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.22",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.22.tgz",
+      "integrity": "sha512-8BSaq/QRGU1+xyi8L2PTLTJU7MH9aMA72RQdIxrbhWFauOZY9OXo8f2YDN/972xA8d588tlnNVEQ2Mo69pT9Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.28",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.28.tgz",
+      "integrity": "sha512-lIAlqUUbBu93FJMlQfslryQtBwwzdzvp23ePC6FNgymXk6Ook5v4Uvc0vdutvoIeqmyA3LfP0ZeRFK8+11kOOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/analytics": "0.10.22",
+        "@firebase/analytics-types": "0.8.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.4.tgz",
+      "integrity": "sha512-zQ+XTgkwH6CY/eUSHJRP7e4LxM30RCxlCmob5sy2axs25GE3Ny0XdgpDscMTHHQIGqWkxPXad4w2Mw9sCgT8zQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.15.0.tgz",
+      "integrity": "sha512-soIskolmGgbpi0K/MfrjtdpO1220qRCbXA4Z8Qx3lM+fVwA3q40m+OM+7zBHd2nuQCrLXb33L6Oc1aBH3Y26AQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.12.0.tgz",
+      "integrity": "sha512-wMeT6HLWRAuW7Cp/5UjWBGKgjPNxWNOoNf4PRIv0weljoGMZVeqbUY7wNBWTI2/31cX1NlXx8gQruDLsUShB3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.5.tgz",
+      "integrity": "sha512-JI17mVcZs34zO6ZeSCrw4U2iohqy+n6GIzkbmsA+TbVjmvFLkUKt3bs5M+qRBteQm/0IWzqSHYFzEQLzDTQebg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check": "0.12.0",
+        "@firebase/app-check-types": "0.5.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.4.tgz",
+      "integrity": "sha512-zz3i6e13B8BfWiLy8MABtTh8aGIACgKbf9UVnyHcWs+yQzJXgQcl8A46b0zfaiJHdQ+niF0ouAfcpuf+3LMPQg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.4.tgz",
+      "integrity": "sha512-xV7JsIyzVr15aA7f3Pi0rB9gdBuVubs89FGA8VkRYA4g0l78poADgdfrScgf7NndSg9mm7cR7PJyY0+t22KaGw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.14.tgz",
+      "integrity": "sha512-rgFmiofYsdS9ZG/Bht3OBxJtPD3zWE1cffShWubEm+4+qZeyzCbmtb1q6jOEjN9fB7uufe4rQmWOPXouR3758Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app": "0.15.0",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.5.tgz",
+      "integrity": "sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/logger": "0.5.1"
+      }
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.3.tgz",
+      "integrity": "sha512-bqiq4uubDN2YyQkdvSWPQeJyXAv2O76ImF41En9b6UhV5JuBVYDoHYrrrE3NzIuGkpFMKagfhMRP4Vz6t+yQSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.8.tgz",
+      "integrity": "sha512-llcBREUC4iSNKZ6rvwud7Oz9Q7aAWU6KuQLa6pdu7Q+QAQsy4JLw6yFgxwtmzabsgznHmmcsX2UjHLLzqUxi3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth": "1.13.3",
+        "@firebase/auth-types": "0.13.1",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.5.tgz",
+      "integrity": "sha512-1Li/YuBDBAXcKv7BzY4U28gontUmAaw53sYiqbaVOMCFb2lFKK/c3CGMUWqtwe7+TXrl3poWnTCL5umYBg85Eg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.1.tgz",
+      "integrity": "sha512-0c1Mnid0uMDfGJHeUS4zfvBa4/CedJXotGy/n/NZJnBjwiJawt0ZYU+wH2VAVLiRCEfG2ncCkAX3yd1/2nrB7g==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.3.tgz",
+      "integrity": "sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/data-connect": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.7.1.tgz",
+      "integrity": "sha512-2LbUU8mmSA63HknxQMmWHjpzuNLBKflvVwQc2tpoVKg0biWleNEJX031ELks0vzFs+dDjOUkCJR72RP6mQHFOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.3.tgz",
+      "integrity": "sha512-XwWCa+E4TvNGpGwXrycLRNfdogADwFcvuhyow6wDWma9W54roaQIhe+4PM0KiLsIftBdSCGI7OKCXrdSRHbIhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.4.tgz",
+      "integrity": "sha512-3pK35F1MAgmqFJQlf2nhQl44vtAXQO1uaCaQOEUI9kCRtLFqi7N+QRKR7lFZPg+xIZIyubgxQaxY69YgfZRZWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/database": "1.1.3",
+        "@firebase/database-types": "1.0.20",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.20.tgz",
+      "integrity": "sha512-kegbOk/w8iU64pr0q6k2ItyNGjnQBMHFhwS7ohdWI4W+pc0/zhhdGXTdFj6X1oxItRjPoYOsSQmERgBkn/ihxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-types": "0.9.5",
+        "@firebase/util": "1.15.1"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.16.0.tgz",
+      "integrity": "sha512-qdHMHMvMr0nRMuZyWNR/ArWa0YlPE3C4eAbmxTASJMYXAesKPL0Y54p70moggrNPzaK7MSIIq5RDJJyntQyIYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "@firebase/webchannel-wrapper": "1.0.6",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "re2js": "^0.4.2",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.11.tgz",
+      "integrity": "sha512-W7o1WdwWq5aABK5Up2ncSvTQs/QGLR/fy7cVpFBNqhsXtxoMtflHf2xBIG6+aoptcuGAobddq4g2Sq27wqHaYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/firestore": "4.16.0",
+        "@firebase/firestore-types": "3.0.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.4.tgz",
+      "integrity": "sha512-jGn+JSS4X9zZsrfu7Yw66v5YRdOLD1oyQh4USR0xWl4CUqV/DA6bNIXRPpxH/cUl3iVTNiP6MN7g+EL42A4qfA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.5.tgz",
+      "integrity": "sha512-bWCx713f4kE/uFV7gdFOLBS7lDoiZj48MRkbAqe35gkXcCeWF4QjRNO07Jhmve7EJIoQOBczL29y2r8VRuN1kw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/messaging-interop-types": "0.2.5",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.5.tgz",
+      "integrity": "sha512-10qlUXGY25G5/1g9UihqksPp2po+ZqSE7LEizsrdUP7vrTmkysXxGSZCDyojSEp6mQe/ecRDdDDI+z4XRdb4wQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/functions": "0.13.5",
+        "@firebase/functions-types": "0.6.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.4.tgz",
+      "integrity": "sha512-zV6kgqtduR4rUAdC/ilS7kmb93XD7bEZoJDlVBZqlOw2uGGGCNBQBuleww2rr0Ulr3L9o2TDjumEt68/l1f9DQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.22.tgz",
+      "integrity": "sha512-ef6nn3GGQTdReCfotRMG77PJZu8CqEbiK5pEoBnM0gTu/Z9v0i/az2p3HABsa/1beQmmyh1OsOjf7P5+pgwdZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.22.tgz",
+      "integrity": "sha512-C/zpAuTP5S9OgKSPvXRupw3hoY/JZSlA1wFjD/Sb7LIQE0FNbcMdO8Y4KXVEkjVzma/DDDDIAzxEXqKMAzc88w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/installations-types": "0.5.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.4.tgz",
+      "integrity": "sha512-U2eFapdHwjb43Vx9o+Pmj4dFfvcHEK1IirEFLqMtWrTHvmdrS3gBpBD1kmJk/9HjsOtoHZxJ2Paoe79e+L1ZPg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.1.tgz",
+      "integrity": "sha512-vZKLsqE1ABOy8OjQiE7cUTFn4gvaqlk88yp8N94Pk/sDpq61YqZGqmVFZTvOyflTwuYFcWirBdYGoJgbDaXKYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.13.0.tgz",
+      "integrity": "sha512-GZoo0uGRvEbszo83xcgbjJp4FpkmBEr4l8Z4hi8gl+P1Spn/MTK3HapanMzSX4yUHuTEiF5hasWRxOaz+o5sxQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/messaging-interop-types": "0.2.5",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.27.tgz",
+      "integrity": "sha512-JNOiu1PPgdHzEPEtoFiNxQuu0x9bm4bfETSQCpGfcTlgWkhlSK7uh7nlsjC10TQLUNgYetLmuutaYTh8aeYLVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/messaging": "0.13.0",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.5.tgz",
+      "integrity": "sha512-tUEKnaAP2Y/MNIqgnriPpV6e5l13Vs/+p2yrd6NGlncPJT9O3a8muYZtdnWe+IJ4fgKLHJVC79n/asxk/N5Msw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.12.tgz",
+      "integrity": "sha512-fe7nV8teUU3OBHlMUZ9Lw4gLhCW2k4m5Uc3pfWGV+fl8uwJQBGp9Q3lqsJ+HSrFu3Q2pJyLAgrClPGSKyDeYgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0",
+        "web-vitals": "^4.2.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.25.tgz",
+      "integrity": "sha512-q6NjTXpIPoFuUmCmMN/maCdTgzT6aExs9xZo+PxfVLj6uLVGvpyAD6XWjmcrb7jChsFBYbq7E5dyNDF7Zhy9kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/performance": "0.7.12",
+        "@firebase/performance-types": "0.2.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.4.tgz",
+      "integrity": "sha512-kJSEk7b0uhpcPRyL4SQ/GPujLqk52XNKcXlnsKDbWGAb9vugcLvOU3u6zfEdwd+d8hWJb5S5ZizV1JFFI0nkKg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.8.5.tgz",
+      "integrity": "sha512-zb+7CDGFP2wYVF1LXQoYIFdoESIQM3p0+uiW1welw8+zvDxAL50K75PKTXXtunJADUrksTVpV7mD0pn54vzJRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.26",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.26.tgz",
+      "integrity": "sha512-uC57Tc7GYYOCnMgLkGIVf999XlaYaPDONoa54c93YTKDctlvCZI89z0zQ2RbhGR8Zf+QuCbQHs/99vqoE84a7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/remote-config": "0.8.5",
+        "@firebase/remote-config-types": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.1.tgz",
+      "integrity": "sha512-cX/1LT6KQwkXzck2eSzeKnuvXZCyr8qaPpDcikoJs7jmI+oBOXixpDLeDtWj1U6GNMkIoXrEDNoyT2Ypcyp5/A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.3.tgz",
+      "integrity": "sha512-YX4/YL6P6/fufSSeGnVhjWddcIXbFq2cWIhMKFTZo1E/Rtcl2mJj/BYUQTwJfcE1Tl8un1FOya4L05jcSLN/Eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.3.tgz",
+      "integrity": "sha512-gruVqjtUGX8tEoeNbaWXZm0Zfcfcb7fvmDmBxV8yPAbWvExRnZYLO2+qw9idxNE7BvPXt5csyjSYHy//dAizxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/storage": "0.14.3",
+        "@firebase/storage-types": "0.8.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.4.tgz",
+      "integrity": "sha512-BT7cwxJOx8SWwlQfrlC+bD/Sk3Cw+1odCi8UZNFNWTVZoPsBnA5W+mqtZzVnvsdJpXCFGSGQ7R7vOR6dtM/BRA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.1.tgz",
+      "integrity": "sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.6.tgz",
+      "integrity": "sha512-Vr/Mqu79dMwGRAyGbJ4uN4+BtXB3/mRTdzetD1daWNeG8QaWuzhhbG77GltO5c0yYmYls8i250iX73624GJd7Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.9.16",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.16.tgz",
+      "integrity": "sha512-wE4Ut/olIzfKqp631XrG+wbF0v1vWFN4YL9FyXC2LJiG33DsV7PLzURjrCvY/6je2ntdRkeLpPDluzSRGaVltQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@img/colour": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
@@ -2053,6 +2697,63 @@
       "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
       "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
       "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.3",
@@ -3525,7 +4226,6 @@
       "version": "22.20.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
       "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -3702,7 +4402,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3891,7 +4590,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -3915,7 +4613,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3928,7 +4625,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/convert-source-map": {
@@ -4104,7 +4800,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
@@ -4225,6 +4920,18 @@
       "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
       "license": "MIT"
     },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -4247,6 +4954,42 @@
       "resolved": "https://registry.npmjs.org/fetchdts/-/fetchdts-0.1.7.tgz",
       "integrity": "sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA==",
       "license": "MIT"
+    },
+    "node_modules/firebase": {
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.15.0.tgz",
+      "integrity": "sha512-p0YTLcRSTiBXMx9sGr4ZNSfLjc/RVBEw4C/TXjVMtw65+6E1Pbm47UY3F4/AqRoDobEcNX3gsbPGy7jPjxbgSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/ai": "2.13.1",
+        "@firebase/analytics": "0.10.22",
+        "@firebase/analytics-compat": "0.2.28",
+        "@firebase/app": "0.15.0",
+        "@firebase/app-check": "0.12.0",
+        "@firebase/app-check-compat": "0.4.5",
+        "@firebase/app-compat": "0.5.14",
+        "@firebase/app-types": "0.9.5",
+        "@firebase/auth": "1.13.3",
+        "@firebase/auth-compat": "0.6.8",
+        "@firebase/data-connect": "0.7.1",
+        "@firebase/database": "1.1.3",
+        "@firebase/database-compat": "2.1.4",
+        "@firebase/firestore": "4.16.0",
+        "@firebase/firestore-compat": "0.4.11",
+        "@firebase/functions": "0.13.5",
+        "@firebase/functions-compat": "0.4.5",
+        "@firebase/installations": "0.6.22",
+        "@firebase/installations-compat": "0.2.22",
+        "@firebase/messaging": "0.13.0",
+        "@firebase/messaging-compat": "0.2.27",
+        "@firebase/performance": "0.7.12",
+        "@firebase/performance-compat": "0.2.25",
+        "@firebase/remote-config": "0.8.5",
+        "@firebase/remote-config-compat": "0.2.26",
+        "@firebase/storage": "0.14.3",
+        "@firebase/storage-compat": "0.4.3",
+        "@firebase/util": "1.15.1"
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -4275,7 +5018,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -4340,6 +5082,12 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "license": "MIT"
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -4368,11 +5116,16 @@
         "node": ">= 14"
       }
     },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "license": "ISC"
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4765,6 +5518,18 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5029,6 +5794,29 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5038,6 +5826,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/re2js": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/re2js/-/re2js-0.4.3.tgz",
+      "integrity": "sha512-EuNmh7jurhHEE8Ge/lBo9JuMLb3qf866Xjjfyovw3wPc7+hlqDkZq4LwhrCQMEI+ARWfrKrHozEndzlpNT0WDg==",
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "19.2.7",
@@ -5084,7 +5878,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5146,6 +5939,26 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.8.1.tgz",
       "integrity": "sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==",
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -5332,7 +6145,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -5347,7 +6159,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -5487,8 +6298,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/typescript": {
       "version": "6.0.3",
@@ -5523,7 +6333,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unenv": {
@@ -5834,6 +6643,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -5849,6 +6664,29 @@
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "license": "MIT"
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/whatwg-mimetype": {
       "version": "5.0.0",
@@ -5951,7 +6789,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -5969,7 +6806,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -6038,7 +6874,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -6054,7 +6889,6 @@
       "version": "17.7.3",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
       "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -6073,7 +6907,6 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"

--- a/app/package.json
+++ b/app/package.json
@@ -24,6 +24,7 @@
     "@tanstack/react-router-with-query": "^1.130.17",
     "@tanstack/react-start": "latest",
     "@tanstack/router-plugin": "^1.132.0",
+    "firebase": "^12.15.0",
     "hls.js": "^1.6.16",
     "lucide-react": "^0.545.0",
     "react": "^19.2.0",

--- a/app/src/components/AnnouncementBanner.test.tsx
+++ b/app/src/components/AnnouncementBanner.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { AnnouncementBanner } from './AnnouncementBanner'
+
+const rc = vi.hoisted(() => ({ value: { announcement: '', killed: new Set<string>(), collections: [] } }))
+vi.mock('../lib/useRemoteConfig', () => ({ useRemoteConfig: () => rc.value }))
+
+afterEach(cleanup)
+
+describe('AnnouncementBanner', () => {
+  it('renders the announcement when set', () => {
+    rc.value = { announcement: 'Maintenance Sunday 02:00 UTC', killed: new Set(), collections: [] }
+    render(<AnnouncementBanner />)
+    expect(screen.getByTestId('announcement').textContent).toContain('Maintenance Sunday')
+  })
+
+  it('renders nothing when the announcement is empty (the default)', () => {
+    rc.value = { announcement: '', killed: new Set(), collections: [] }
+    render(<AnnouncementBanner />)
+    expect(screen.queryByTestId('announcement')).toBeNull()
+  })
+})

--- a/app/src/components/AnnouncementBanner.tsx
+++ b/app/src/components/AnnouncementBanner.tsx
@@ -1,0 +1,14 @@
+import { useRemoteConfig } from '../lib/useRemoteConfig'
+
+// Site-wide maintainer announcement (Remote Config). Client-only: renders nothing
+// on the server / first paint and when the announcement is empty (the default),
+// so it appears only when the maintainer sets one — no deploy needed.
+export function AnnouncementBanner() {
+  const { announcement } = useRemoteConfig()
+  if (!announcement) return null
+  return (
+    <div role="status" data-testid="announcement" className="bg-accent px-4 py-2 text-center text-sm font-medium text-white">
+      {announcement}
+    </div>
+  )
+}

--- a/app/src/components/ChannelRail.test.tsx
+++ b/app/src/components/ChannelRail.test.tsx
@@ -10,8 +10,13 @@ vi.mock('../data/kv', () => ({
     'NDTV.in': { country: 'in', categories: ['news'], name: 'NDTV 24x7' },
   }),
 }))
+const rc = vi.hoisted(() => ({ killed: new Set<string>() }))
+vi.mock('../lib/useRemoteConfig', () => ({ useRemoteConfig: () => ({ announcement: '', killed: rc.killed, collections: [] }) }))
 
-beforeEach(() => localStorage.clear())
+beforeEach(() => {
+  localStorage.clear()
+  rc.killed = new Set()
+})
 afterEach(cleanup)
 
 describe('ChannelRail', () => {
@@ -33,5 +38,12 @@ describe('ChannelRail', () => {
     await waitFor(() => expect(screen.getByText('BBC News')).toBeTruthy())
     expect(screen.queryByText('Ghost.zz')).toBeNull()
     expect(screen.getAllByTestId('channel-card')).toHaveLength(1)
+  })
+
+  it('filters out Remote Config kill-listed channels', async () => {
+    rc.killed = new Set(['BBCNews.uk'])
+    render(<ChannelRail title="Your favorites" ids={['BBCNews.uk', 'NDTV.in']} />)
+    await waitFor(() => expect(screen.getByText('NDTV 24x7')).toBeTruthy())
+    expect(screen.queryByText('BBC News')).toBeNull() // kill-listed → hidden
   })
 })

--- a/app/src/components/ChannelRail.tsx
+++ b/app/src/components/ChannelRail.tsx
@@ -1,12 +1,15 @@
 import { useResolvedChannels } from '../lib/useResolvedChannels'
+import { useRemoteConfig } from '../lib/useRemoteConfig'
 import { ChannelCard } from './ChannelCard'
 
 // A titled rail of channels resolved from a list of IDs (favorites, history,
 // featured). Client-only: the IDs come from localStorage / Remote Config. Renders
 // nothing until there are cards to show — so an empty list, a still-loading index,
 // or all-stale IDs never produce a bare titled section (rails self-omit).
+// Remote Config's kill-list is filtered out (origin R8).
 export function ChannelRail({ title, ids }: { title: string; ids: string[] }) {
-  const { channels } = useResolvedChannels(ids)
+  const { killed } = useRemoteConfig()
+  const { channels } = useResolvedChannels(ids.filter((id) => !killed.has(id)))
   if (channels.length === 0) return null
 
   return (

--- a/app/src/components/LiveNowBoard.tsx
+++ b/app/src/components/LiveNowBoard.tsx
@@ -2,6 +2,7 @@ import { Link } from '@tanstack/react-router'
 import type { EpgShard, EpgMeta } from '../data/types'
 import { currentlyAiring, boardEligible } from '../lib/epg'
 import { useNow } from '../lib/useNow'
+import { useRemoteConfig } from '../lib/useRemoteConfig'
 
 // "Live now" board (origin R5/R6/R8). Client-only: which channels are airing now
 // depends on the viewer's clock (a ticking useNow, so it advances mid-session),
@@ -22,9 +23,10 @@ export function LiveNowBoard({
   nameById: Record<string, string>
 }) {
   const now = useNow()
+  const { killed } = useRemoteConfig() // hook must run before any early return
   if (now == null || !meta) return null
 
-  const airing = currentlyAiring(shard, now)
+  const airing = currentlyAiring(shard, now).filter((a) => !killed.has(a.channelId)) // R8
   if (!boardEligible(meta, coverage, airing.length)) return null
 
   const rows = airing.slice(0, MAX_ROWS)

--- a/app/src/lib/rc.test.ts
+++ b/app/src/lib/rc.test.ts
@@ -33,11 +33,11 @@ describe('deriveRcState', () => {
     expect([...s.killed].sort()).toEqual(['x', 'y'])
   })
 
-  it('drops malformed collection entries (missing title / bad channelIds)', () => {
+  it('drops malformed collection entries (missing/empty title, bad channelIds)', () => {
     const s = deriveRcState({
-      featured_collections: '[{"title":"Good","channelIds":["a"]},{"channelIds":["b"]},{"title":"NoIds"},{"title":"BadIds","channelIds":"x"}]',
+      featured_collections: '[{"title":"Good","channelIds":["a"]},{"channelIds":["b"]},{"title":"NoIds"},{"title":"BadIds","channelIds":"x"},{"title":"  ","channelIds":["c"]}]',
     })
-    expect(s.collections).toEqual([{ title: 'Good', channelIds: ['a'] }])
+    expect(s.collections).toEqual([{ title: 'Good', channelIds: ['a'] }]) // empty/whitespace title also dropped
   })
 
   it('ignores non-string entries inside the kill-list and channelIds', () => {

--- a/app/src/lib/rc.test.ts
+++ b/app/src/lib/rc.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { deriveRcState } from './rc'
+
+describe('deriveRcState', () => {
+  it('parses a valid announcement, kill-list, and featured collections', () => {
+    const s = deriveRcState({
+      announcement: 'Maintenance Sunday',
+      killed_channel_ids: '["a.uk","b.in"]',
+      featured_collections: '[{"title":"Top News","channelIds":["a.uk"]},{"title":"Sport","channelIds":["c.us"]}]',
+    })
+    expect(s.announcement).toBe('Maintenance Sunday')
+    expect([...s.killed].sort()).toEqual(['a.uk', 'b.in'])
+    expect(s.collections).toHaveLength(2)
+    expect(s.collections[0]).toEqual({ title: 'Top News', channelIds: ['a.uk'] })
+  })
+
+  it('malformed JSON in any field falls back to empty (never throws)', () => {
+    const s = deriveRcState({ announcement: 'ok', killed_channel_ids: '{not json', featured_collections: 'nope' })
+    expect(s.announcement).toBe('ok')
+    expect(s.killed.size).toBe(0)
+    expect(s.collections).toEqual([])
+  })
+
+  it('all-default/empty input yields empty state', () => {
+    const s = deriveRcState({})
+    expect(s.announcement).toBe('')
+    expect(s.killed.size).toBe(0)
+    expect(s.collections).toEqual([])
+  })
+
+  it('deduplicates ids in the kill-list into the Set', () => {
+    const s = deriveRcState({ killed_channel_ids: '["x","x","y"]' })
+    expect([...s.killed].sort()).toEqual(['x', 'y'])
+  })
+
+  it('drops malformed collection entries (missing title / bad channelIds)', () => {
+    const s = deriveRcState({
+      featured_collections: '[{"title":"Good","channelIds":["a"]},{"channelIds":["b"]},{"title":"NoIds"},{"title":"BadIds","channelIds":"x"}]',
+    })
+    expect(s.collections).toEqual([{ title: 'Good', channelIds: ['a'] }])
+  })
+
+  it('ignores non-string entries inside the kill-list and channelIds', () => {
+    const s = deriveRcState({
+      killed_channel_ids: '["a",1,null,"b"]',
+      featured_collections: '[{"title":"C","channelIds":["a",2,"b"]}]',
+    })
+    expect([...s.killed].sort()).toEqual(['a', 'b'])
+    expect(s.collections[0].channelIds).toEqual(['a', 'b'])
+  })
+})

--- a/app/src/lib/rc.ts
+++ b/app/src/lib/rc.ts
@@ -42,7 +42,7 @@ export function deriveRcState(raw: RcRaw): RcState {
     .map((c): FeaturedCollection | null => {
       if (!c || typeof c !== 'object') return null
       const { title, channelIds } = c as Record<string, unknown>
-      if (typeof title !== 'string' || !Array.isArray(channelIds)) return null
+      if (typeof title !== 'string' || title.trim() === '' || !Array.isArray(channelIds)) return null
       return { title, channelIds: stringsOf(channelIds) }
     })
     .filter((c): c is FeaturedCollection => c !== null)

--- a/app/src/lib/rc.ts
+++ b/app/src/lib/rc.ts
@@ -1,0 +1,55 @@
+// Pure Remote Config parsing. RC parameters arrive as strings (JSON-typed params
+// are returned as their raw JSON string), so we parse defensively here — a bad
+// edit in the Firebase console must never crash the site. No Firebase import:
+// this is the tested core; remoteConfig.client.ts does the browser-only fetch.
+
+export interface FeaturedCollection {
+  title: string
+  channelIds: string[]
+}
+
+export interface RcState {
+  announcement: string
+  killed: Set<string>
+  collections: FeaturedCollection[]
+}
+
+/** In-app defaults — every RC reader falls back to these, so the site works with no RC. */
+export const RC_DEFAULTS = {
+  announcement: '',
+  killed_channel_ids: '[]',
+  featured_collections: '[]',
+}
+
+export type RcRaw = { announcement?: string; killed_channel_ids?: string; featured_collections?: string }
+
+function parseJson<T>(raw: string | undefined, fallback: T): T {
+  if (!raw) return fallback
+  try {
+    return JSON.parse(raw) as T
+  } catch {
+    return fallback
+  }
+}
+
+const stringsOf = (v: unknown): string[] => (Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : [])
+
+/** Parse the three RC params into a typed, defensively-validated state. */
+export function deriveRcState(raw: RcRaw): RcState {
+  const killedList = stringsOf(parseJson<unknown>(raw.killed_channel_ids, []))
+  const rawCollections = parseJson<unknown>(raw.featured_collections, [])
+  const collections: FeaturedCollection[] = (Array.isArray(rawCollections) ? rawCollections : [])
+    .map((c): FeaturedCollection | null => {
+      if (!c || typeof c !== 'object') return null
+      const { title, channelIds } = c as Record<string, unknown>
+      if (typeof title !== 'string' || !Array.isArray(channelIds)) return null
+      return { title, channelIds: stringsOf(channelIds) }
+    })
+    .filter((c): c is FeaturedCollection => c !== null)
+
+  return {
+    announcement: typeof raw.announcement === 'string' ? raw.announcement : '',
+    killed: new Set(killedList),
+    collections,
+  }
+}

--- a/app/src/lib/remoteConfig.client.ts
+++ b/app/src/lib/remoteConfig.client.ts
@@ -7,8 +7,8 @@
 // they're absent, getRC() returns null → the app runs on RC defaults (no control
 // plane, fully functional).
 import { initializeApp, getApps, getApp } from 'firebase/app'
-import { getRemoteConfig, isSupported, type RemoteConfig } from 'firebase/remote-config'
-import { RC_DEFAULTS } from './rc'
+import { getRemoteConfig, isSupported, fetchAndActivate, getString, type RemoteConfig } from 'firebase/remote-config'
+import { RC_DEFAULTS, deriveRcState, type RcState } from './rc'
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY as string | undefined,
@@ -37,4 +37,20 @@ export function getRC(): Promise<RemoteConfig | null> {
     }
   })()
   return rcPromise
+}
+
+/**
+ * Fetch + activate RC and return the parsed state, or null when RC is off/failed.
+ * All Firebase access is confined to this .client module so the SSR-reachable
+ * useRemoteConfig hook never references firebase/* (TanStack Start import guard).
+ */
+export async function loadRcState(): Promise<RcState | null> {
+  const rc = await getRC()
+  if (!rc) return null
+  await fetchAndActivate(rc)
+  return deriveRcState({
+    announcement: getString(rc, 'announcement'),
+    killed_channel_ids: getString(rc, 'killed_channel_ids'),
+    featured_collections: getString(rc, 'featured_collections'),
+  })
 }

--- a/app/src/lib/remoteConfig.client.ts
+++ b/app/src/lib/remoteConfig.client.ts
@@ -1,0 +1,40 @@
+// Browser-ONLY Firebase Remote Config init. The RC SDK uses window + IndexedDB and
+// must never run in the Cloudflare SSR worker — so this module is reached SOLELY
+// via `await import()` inside useRemoteConfig's effect, never statically imported
+// by SSR-evaluated code. (A build check greps the worker bundle for `firebase`.)
+//
+// Config keys are PUBLIC web identifiers (via VITE_FIREBASE_*), not secrets. When
+// they're absent, getRC() returns null → the app runs on RC defaults (no control
+// plane, fully functional).
+import { initializeApp, getApps, getApp } from 'firebase/app'
+import { getRemoteConfig, isSupported, type RemoteConfig } from 'firebase/remote-config'
+import { RC_DEFAULTS } from './rc'
+
+const firebaseConfig = {
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY as string | undefined,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID as string | undefined,
+  appId: import.meta.env.VITE_FIREBASE_APP_ID as string | undefined,
+}
+
+let rcPromise: Promise<RemoteConfig | null> | null = null
+
+/** Get the initialized RemoteConfig, or null (unconfigured / unsupported / failed). */
+export function getRC(): Promise<RemoteConfig | null> {
+  if (typeof window === 'undefined') return Promise.resolve(null)
+  if (rcPromise) return rcPromise
+  rcPromise = (async () => {
+    try {
+      if (!firebaseConfig.apiKey) return null // no Firebase project → RC off
+      if (!(await isSupported())) return null // no IndexedDB (private mode etc.) → RC off
+      const app = getApps().length ? getApp() : initializeApp(firebaseConfig)
+      const rc = getRemoteConfig(app)
+      rc.settings.minimumFetchIntervalMillis = 30 * 60 * 1000 // 30 min — respects the free-tier throttle
+      rc.settings.fetchTimeoutMillis = 10_000
+      rc.defaultConfig = RC_DEFAULTS
+      return rc
+    } catch {
+      return null // any init failure → defaults
+    }
+  })()
+  return rcPromise
+}

--- a/app/src/lib/useRemoteConfig.test.tsx
+++ b/app/src/lib/useRemoteConfig.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { useRemoteConfig } from './useRemoteConfig'
+
+// With no VITE_FIREBASE_* config (the test/dev default), getRC() returns null and
+// the hook stays on defaults — the site's "RC never loads" path. It must render
+// defaults without throwing.
+function Probe() {
+  const rc = useRemoteConfig()
+  return (
+    <div>
+      <span data-testid="announcement">{rc.announcement || '(none)'}</span>
+      <span data-testid="killed">{rc.killed.size}</span>
+      <span data-testid="collections">{rc.collections.length}</span>
+    </div>
+  )
+}
+
+afterEach(cleanup)
+
+describe('useRemoteConfig (defaults-safe)', () => {
+  it('renders default config (empty) when Firebase is not configured, without throwing', async () => {
+    render(<Probe />)
+    // Let the mount effect + any dynamic import settle.
+    await new Promise((r) => setTimeout(r, 30))
+    expect(screen.getByTestId('announcement').textContent).toBe('(none)')
+    expect(screen.getByTestId('killed').textContent).toBe('0')
+    expect(screen.getByTestId('collections').textContent).toBe('0')
+  })
+})

--- a/app/src/lib/useRemoteConfig.ts
+++ b/app/src/lib/useRemoteConfig.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
-import { deriveRcState, type RcState } from './rc'
+import { createClientOnlyFn } from '@tanstack/react-start'
+import type { RcState } from './rc'
 
 // Client-only Remote Config reader. Returns defaults on the server and first paint
 // (so SSR HTML matches — no hydration mismatch), then fills in after a single
@@ -14,21 +15,23 @@ let started = false
 const listeners = new Set<() => void>()
 const emit = () => listeners.forEach((fn) => fn())
 
+// createClientOnlyFn marks this as browser-only: it no-ops (returns undefined) on
+// the server and satisfies TanStack Start's import guard, so the dynamically-loaded
+// firebase never enters the SSR worker bundle.
+const loadRcStateClient = createClientOnlyFn(async (): Promise<RcState | null> => {
+  const { loadRcState } = await import('./remoteConfig.client')
+  return loadRcState()
+})
+
 async function ensureLoaded(): Promise<void> {
   if (started || typeof window === 'undefined') return
   started = true
   try {
-    const { getRC } = await import('./remoteConfig.client')
-    const rc = await getRC()
-    if (!rc) return // unconfigured / unsupported → stay on defaults
-    const { fetchAndActivate, getString } = await import('firebase/remote-config')
-    await fetchAndActivate(rc)
-    shared = deriveRcState({
-      announcement: getString(rc, 'announcement'),
-      killed_channel_ids: getString(rc, 'killed_channel_ids'),
-      featured_collections: getString(rc, 'featured_collections'),
-    })
-    emit()
+    const state = await loadRcStateClient()
+    if (state) {
+      shared = state
+      emit()
+    }
   } catch {
     /* offline / throttled / misconfigured → keep defaults; site works */
   }

--- a/app/src/lib/useRemoteConfig.ts
+++ b/app/src/lib/useRemoteConfig.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react'
+import { deriveRcState, type RcState } from './rc'
+
+// Client-only Remote Config reader. Returns defaults on the server and first paint
+// (so SSR HTML matches — no hydration mismatch), then fills in after a single
+// fetch shared across all consumers. Firebase is reached only via dynamic import
+// here, so it never enters the SSR worker bundle. Every path falls back to
+// defaults, so the site is fully functional whether or not RC ever loads.
+
+const DEFAULT_STATE: RcState = { announcement: '', killed: new Set(), collections: [] }
+
+let shared: RcState = DEFAULT_STATE
+let started = false
+const listeners = new Set<() => void>()
+const emit = () => listeners.forEach((fn) => fn())
+
+async function ensureLoaded(): Promise<void> {
+  if (started || typeof window === 'undefined') return
+  started = true
+  try {
+    const { getRC } = await import('./remoteConfig.client')
+    const rc = await getRC()
+    if (!rc) return // unconfigured / unsupported → stay on defaults
+    const { fetchAndActivate, getString } = await import('firebase/remote-config')
+    await fetchAndActivate(rc)
+    shared = deriveRcState({
+      announcement: getString(rc, 'announcement'),
+      killed_channel_ids: getString(rc, 'killed_channel_ids'),
+      featured_collections: getString(rc, 'featured_collections'),
+    })
+    emit()
+  } catch {
+    /* offline / throttled / misconfigured → keep defaults; site works */
+  }
+}
+
+export function useRemoteConfig(): RcState {
+  const [state, setState] = useState<RcState>(DEFAULT_STATE)
+  useEffect(() => {
+    const update = () => setState(shared)
+    update() // adopt already-loaded config if a prior consumer fetched it
+    listeners.add(update)
+    void ensureLoaded()
+    return () => {
+      listeners.delete(update)
+    }
+  }, [])
+  return state
+}

--- a/app/src/lib/useRemoteConfig.ts
+++ b/app/src/lib/useRemoteConfig.ts
@@ -32,8 +32,12 @@ async function ensureLoaded(): Promise<void> {
       shared = state
       emit()
     }
+    // state === null means RC is off (unconfigured/unsupported) — don't retry.
   } catch {
-    /* offline / throttled / misconfigured → keep defaults; site works */
+    // Transient failure (offline / throttled) → keep defaults but allow a retry
+    // on the next consumer mount (e.g. after a navigation) instead of pinning the
+    // whole session to defaults.
+    started = false
   }
 }
 

--- a/app/src/routes/__root.tsx
+++ b/app/src/routes/__root.tsx
@@ -2,6 +2,7 @@ import { HeadContent, Scripts, Link, createRootRoute } from '@tanstack/react-rou
 import { TanStackRouterDevtoolsPanel } from '@tanstack/react-router-devtools'
 import { TanStackDevtools } from '@tanstack/react-devtools'
 import { Star } from 'lucide-react'
+import { AnnouncementBanner } from '../components/AnnouncementBanner'
 
 import appCss from '../styles.css?url'
 
@@ -88,6 +89,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         <HeadContent />
       </head>
       <body className="flex min-h-screen flex-col">
+        <AnnouncementBanner />
         <SiteHeader />
         <div className="flex-1">{children}</div>
         <SiteFooter />

--- a/app/src/routes/category.$slug.tsx
+++ b/app/src/routes/category.$slug.tsx
@@ -3,6 +3,7 @@ import { getStore } from '../data/store'
 import { getCategory, getChannelIndex, getEpgShard, getEpgMeta } from '../data/kv'
 import { LiveNowBoard } from '../components/LiveNowBoard'
 import { StructuredData } from '../components/StructuredData'
+import { useRemoteConfig } from '../lib/useRemoteConfig'
 import type { EpgShard } from '../data/types'
 
 export const Route = createFileRoute('/category/$slug')({
@@ -37,7 +38,9 @@ export const Route = createFileRoute('/category/$slug')({
 })
 
 function CategoryPage() {
-  const { slug, items, epg, epgMeta, coverage } = Route.useLoaderData()
+  const { slug, items: allItems, epg, epgMeta, coverage } = Route.useLoaderData()
+  const { killed } = useRemoteConfig() // hide kill-listed channels (R8)
+  const items = allItems.filter((it) => !killed.has(it.id))
   const itemList = {
     '@context': 'https://schema.org',
     '@type': 'ItemList',

--- a/app/src/routes/channel.$id.tsx
+++ b/app/src/routes/channel.$id.tsx
@@ -8,6 +8,7 @@ import { LivenessHint } from '../components/LivenessHint'
 import { NowNext } from '../components/NowNext'
 import { FavoriteButton } from '../components/FavoriteButton'
 import { recordWatched } from '../lib/useEngagement'
+import { useRemoteConfig } from '../lib/useRemoteConfig'
 import { broadcastEvents } from '../lib/jsonld'
 
 export const Route = createFileRoute('/channel/$id')({
@@ -34,8 +35,13 @@ export const Route = createFileRoute('/channel/$id')({
 
 function ChannelPage() {
   const { channel, schedule } = Route.useLoaderData()
-  // Opening a channel page counts as a watch (recently-watched, client-only).
-  useEffect(() => recordWatched(channel.id), [channel.id])
+  const { killed } = useRemoteConfig()
+  const isKilled = killed.has(channel.id) // maintainer kill-switch (R8) — hide playback
+  // Opening a channel page counts as a watch (recently-watched, client-only) — but
+  // not a kill-switched one.
+  useEffect(() => {
+    if (!isKilled) recordWatched(channel.id)
+  }, [channel.id, isKilled])
   // Absolute-UTC BroadcastEvents for the current + upcoming schedule (R9), else a
   // single generic live event. Emitted via a JSON-LD script (dangerouslySetInnerHTML),
   // so the request-time `now` used to drop past programmes isn't hydration-diffed.
@@ -69,8 +75,16 @@ function ChannelPage() {
           className="mt-1 shrink-0 rounded-full border border-line p-2 text-muted transition hover:border-accent hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         />
       </div>
-      <Player channel={channel} />
-      <NowNext schedule={schedule ?? undefined} className="mt-4 text-sm text-muted" />
+      {isKilled ? (
+        <div className="flex aspect-video w-full flex-col items-center justify-center rounded-xl bg-ink p-6 text-center" data-testid="channel-unavailable">
+          <p className="text-sm text-white/80">This channel isn’t available.</p>
+        </div>
+      ) : (
+        <>
+          <Player channel={channel} />
+          <NowNext schedule={schedule ?? undefined} className="mt-4 text-sm text-muted" />
+        </>
+      )}
       <section className="mt-5 flex items-center gap-3 border-t border-line pt-5">
         {channel.logo && <img src={channel.logo} alt="" className="h-12 w-12 rounded-md bg-white object-contain p-0.5 ring-1 ring-line" />}
         <div className="text-sm">

--- a/app/src/routes/channel.$id.tsx
+++ b/app/src/routes/channel.$id.tsx
@@ -58,7 +58,9 @@ function ChannelPage() {
   // Mobile: player above the fold (rendered before the metadata block).
   return (
     <main className="mx-auto max-w-3xl px-4 py-6 sm:px-6">
-      <StructuredData data={videoObject} />
+      {/* Don't advertise a killed channel as a watchable VideoObject once RC resolves
+          (client-side; SSR still emits it until the pipeline removes the channel — R8). */}
+      {!isKilled && <StructuredData data={videoObject} />}
       <nav aria-label="Breadcrumb" className="mb-4 font-mono text-xs uppercase tracking-wide text-muted">
         <Link to="/" className="transition hover:text-accent-ink">Home</Link>
         {channel.country && (

--- a/app/src/routes/country.$code.tsx
+++ b/app/src/routes/country.$code.tsx
@@ -4,6 +4,7 @@ import { getCountry, getEpgShard, getEpgMeta } from '../data/kv'
 import { ChannelCard } from '../components/ChannelCard'
 import { LiveNowBoard } from '../components/LiveNowBoard'
 import { StructuredData } from '../components/StructuredData'
+import { useRemoteConfig } from '../lib/useRemoteConfig'
 
 export const Route = createFileRoute('/country/$code')({
   loader: async ({ params }) => {
@@ -22,7 +23,9 @@ export const Route = createFileRoute('/country/$code')({
 })
 
 function CountryPage() {
-  const { code, channels, epg, epgMeta } = Route.useLoaderData()
+  const { code, channels: allChannels, epg, epgMeta } = Route.useLoaderData()
+  const { killed } = useRemoteConfig() // client-side: hide kill-listed channels (R8)
+  const channels = allChannels.filter((c) => !killed.has(c.id))
   const itemList = {
     '@context': 'https://schema.org',
     '@type': 'ItemList',

--- a/app/src/routes/favorites.tsx
+++ b/app/src/routes/favorites.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Link } from '@tanstack/react-router'
 import { ChannelCard } from '../components/ChannelCard'
 import { useFavorites } from '../lib/useEngagement'
 import { useResolvedChannels } from '../lib/useResolvedChannels'
+import { useRemoteConfig } from '../lib/useRemoteConfig'
 
 export const Route = createFileRoute('/favorites')({
   head: () => ({ meta: [{ title: 'Your favorites — FreeTV' }] }),
@@ -12,7 +13,8 @@ export const Route = createFileRoute('/favorites')({
 // the favorite IDs, resolve their metadata from the channel index, render a grid.
 function FavoritesPage() {
   const favorites = useFavorites()
-  const { channels, loading } = useResolvedChannels(favorites)
+  const { killed } = useRemoteConfig() // hide kill-listed channels (R8)
+  const { channels, loading } = useResolvedChannels(favorites.filter((id) => !killed.has(id)))
 
   return (
     <main className="mx-auto max-w-5xl px-4 py-8 sm:px-6">

--- a/app/src/routes/favorites.tsx
+++ b/app/src/routes/favorites.tsx
@@ -13,8 +13,9 @@ export const Route = createFileRoute('/favorites')({
 // the favorite IDs, resolve their metadata from the channel index, render a grid.
 function FavoritesPage() {
   const favorites = useFavorites()
-  const { killed } = useRemoteConfig() // hide kill-listed channels (R8)
-  const { channels, loading } = useResolvedChannels(favorites.filter((id) => !killed.has(id)))
+  const { killed } = useRemoteConfig()
+  const { channels: resolved, loading } = useResolvedChannels(favorites) // unfiltered → distinguishes stale vs killed
+  const channels = resolved.filter((c) => !killed.has(c.id)) // hide kill-listed for display (R8)
 
   return (
     <main className="mx-auto max-w-5xl px-4 py-8 sm:px-6">
@@ -28,9 +29,13 @@ function FavoritesPage() {
         </p>
       ) : loading ? (
         <p className="text-muted">Loading…</p>
-      ) : channels.length === 0 ? (
+      ) : resolved.length === 0 ? (
         <p className="rounded-xl border border-line bg-surface p-6 text-muted" data-testid="favorites-stale">
           Your saved channels are no longer in the catalog.
+        </p>
+      ) : channels.length === 0 ? (
+        <p className="rounded-xl border border-line bg-surface p-6 text-muted" data-testid="favorites-unavailable">
+          Your favorites are temporarily unavailable.
         </p>
       ) : (
         <div className="rise-in grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3" data-testid="favorites-grid">

--- a/app/src/routes/index.tsx
+++ b/app/src/routes/index.tsx
@@ -77,8 +77,8 @@ function Home() {
       <div className="pt-10">
         <ChannelRail title="Your favorites" ids={favorites} />
         <ChannelRail title="Recently watched" ids={history} />
-        {collections.map((c) => (
-          <ChannelRail key={c.title} title={c.title} ids={c.channelIds} />
+        {collections.map((c, i) => (
+          <ChannelRail key={`featured-${i}`} title={c.title} ids={c.channelIds} />
         ))}
       </div>
 

--- a/app/src/routes/index.tsx
+++ b/app/src/routes/index.tsx
@@ -3,6 +3,7 @@ import { getStore } from '../data/store'
 import { getChannelIndex } from '../data/kv'
 import { ChannelRail } from '../components/ChannelRail'
 import { useFavorites, useHistory } from '../lib/useEngagement'
+import { useRemoteConfig } from '../lib/useRemoteConfig'
 
 export const Route = createFileRoute('/')({
   loader: async () => {
@@ -37,6 +38,7 @@ function Home() {
   const navigate = useNavigate()
   const favorites = useFavorites()
   const history = useHistory()
+  const { collections } = useRemoteConfig() // maintainer-featured rails (R7)
   return (
     <main className="mx-auto max-w-5xl px-4 sm:px-6">
       {/* Hero */}
@@ -71,10 +73,13 @@ function Home() {
         </form>
       </section>
 
-      {/* Device-local engagement rails (client-only; self-omit while empty). */}
+      {/* Device-local engagement + maintainer-featured rails (client-only; self-omit while empty). */}
       <div className="pt-10">
         <ChannelRail title="Your favorites" ids={favorites} />
         <ChannelRail title="Recently watched" ids={history} />
+        {collections.map((c) => (
+          <ChannelRail key={c.title} title={c.title} ids={c.channelIds} />
+        ))}
       </div>
 
       <div className="py-10">

--- a/app/src/routes/search.tsx
+++ b/app/src/routes/search.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { getStore } from '../data/store'
 import { getChannelIndex } from '../data/kv'
+import { useRemoteConfig } from '../lib/useRemoteConfig'
 
 export const Route = createFileRoute('/search')({
   validateSearch: (search: Record<string, unknown>) => ({ q: String(search.q ?? '') }),
@@ -30,7 +31,9 @@ export const Route = createFileRoute('/search')({
 })
 
 function SearchPage() {
-  const { q, channels, countries, categories } = Route.useLoaderData()
+  const { q, channels: allChannels, countries, categories } = Route.useLoaderData()
+  const { killed } = useRemoteConfig() // hide kill-listed channels (R8)
+  const channels = allChannels.filter((c) => !killed.has(c.id))
   const empty = channels.length === 0 && countries.length === 0 && categories.length === 0
   return (
     <main className="mx-auto max-w-3xl px-4 py-8 sm:px-6">


### PR DESCRIPTION
## What & why

**PR 2 of the v2 Engagement feature** (plan: `docs/plans/2026-07-02-001-feat-v2-engagement-plan.md`) — **Phase C**: a client-side **Firebase Remote Config** control plane that lets the maintainer, with no deploy:
- **feature** collections as home rails,
- post a site-wide **announcement**,
- **kill-switch** channel IDs out of browse/boards/rendering.

Everything **degrades to defaults** — with no Firebase project configured (the current state), the site works exactly as it does today; RC simply does nothing.

## How it works

- `app/src/lib/rc.ts` — pure, tested `deriveRcState`: defensively parses the three RC params (`announcement` string, `killed_channel_ids` JSON array, `featured_collections` JSON `[{title,channelIds}]`) — a bad console edit can never crash the site.
- `app/src/lib/remoteConfig.client.ts` — **browser-only** Firebase init + `loadRcState` (fetch/activate). All `firebase/*` usage is confined here.
- `app/src/lib/useRemoteConfig.ts` — a module-shared, SSR-safe hook (defaults on server + first paint, one fetch across all consumers, subscribe/notify). Firebase is loaded via `createClientOnlyFn(() => import('./remoteConfig.client'))`, so **it never enters the Cloudflare SSR worker bundle** (build-verified).
- Application: `AnnouncementBanner` in the shell; kill-switch filter at every list surface (`country`/`category`/`search`/`LiveNowBoard`/home rails/`favorites`) + a killed-channel "unavailable" notice on the channel page; featured rails from `collections` on home.

## Testing

- **111 app tests pass** — `deriveRcState` (valid/malformed/empty/dedupe/empty-title rejection), the defaults-safe hook, the announcement banner, and the kill-filter (via a mocked `useRemoteConfig`).
- **Build-verified**: `firebase` appears in **0** server-bundle files and **1** client chunk. (`createClientOnlyFn` also resolved a TanStack Start import-guard build error.)
- **Browser-verified defaults-safe**: with no `VITE_FIREBASE_*`, home + country render normally (no banner, no featured, nothing hidden), zero console errors.

## Review

Two high-effort multi-agent passes. **Fixed**: transient-RC-failure now allows a later retry (was pinning the session to defaults); a killed channel no longer emits `VideoObject`/`BroadcastEvent` JSON-LD once RC resolves; `/favorites` distinguishes all-killed ("temporarily unavailable") from stale ("no longer in the catalog"); featured rails keyed by index (no collision on duplicate titles); empty/whitespace collection titles rejected.

### Accepted by design (documented — origin R8)
- **The kill-switch is a client-side UI lever, not a takedown.** RC loads after hydration, so a killed channel briefly renders and remains in **SSR HTML / crawler view** until the pipeline removes it. This is intentional: the fast lever stops *new* client rendering while the durable removal (pipeline curate + cache purge) proceeds. A killed channel recorded to *device-local* recently-watched is harmless — the rail filters it from display.
- **Self-contained hook, not TanStack Query** — the app wires no QueryClient for components, so RC is a small SSR-safe external store rather than `useQuery`.

## Post-Deploy Monitoring & Validation

To activate: create a Firebase project (Spark, no billing), set the public `VITE_FIREBASE_*` in the Cloudflare env, and define the three RC params. Absent that, no monitoring needed — the feature is inert and the site is unaffected. Once live, verify a kill-listed ID disappears from browse client-side and an announcement string shows the banner — both with no deploy. Rollback = revert. RC stores only config, no per-user data (honors no-cloud-user-data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
