### PR TITLE
feat: server-only live-KV wiring (fixture in dev, KV in prod)

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -11,3 +11,4 @@ dist-ssr
 .vinxi
 __unconfig*
 todos.json
+worker-configuration.d.ts

--- a/app/DEPLOY.md
+++ b/app/DEPLOY.md
@@ -13,26 +13,38 @@ npm run test       # vitest unit/component tests
 npm run build      # client + Worker SSR bundles
 ```
 
-## Going live (remaining integration step)
+## Server-only KV wiring (✅ done)
 
-1. **Create the KV namespace** and put its id in `wrangler.jsonc` (`SNAPSHOT_KV` binding):
+The loaders now read KV through **server functions**, so the binding never reaches the
+client bundle, even on client-side navigation:
+
+- `src/data/server.ts` holds `createServerFn` wrappers (`fetchHomeData`, `fetchCountryData`,
+  `fetchCategoryData`, `fetchChannelData`, `fetchSearchData`, `fetchChannelIndex`). Only this
+  file imports `env` from `cloudflare:workers`; the Start Vite plugin strips server-fn bodies
+  from the client bundle, so KV / the binding stay server-only (verified: 0 in `dist/client`).
+- Route loaders and the sitemap handler call those fns; the client hook `useResolvedChannels`
+  (favorites / recently-watched / featured rails) calls `fetchChannelIndex` — a Worker RPC —
+  instead of reading the store client-side.
+- `getStore(env)` gates on `import.meta.env.DEV`: **dev/test always use the bundled fixture**
+  (the Cloudflare Vite plugin provides a real-but-EMPTY Miniflare KV binding in `vite dev`, so
+  gating on binding presence would serve empty data). In the built Worker it reads `SNAPSHOT_KV`.
+- Types: `cloudflare:workers` has a minimal ambient decl (`src/cloudflare-workers.d.ts`); run
+  `npm run cf-typegen` for the full generated Cloudflare runtime types (gitignored).
+
+## Going live (remaining ops — needs a Cloudflare account + a live KV)
+
+1. **Create the KV namespace** and paste its id into `wrangler.jsonc` (`SNAPSHOT_KV`, currently
+   `REPLACE_WITH_KV_NAMESPACE_ID`):
    ```
    npx wrangler kv namespace create SNAPSHOT_KV
    ```
-2. **Seed it** — the pipeline already publishes to KV when its CF secrets are set
-   (`pipeline/src/publish-kv.js`); point the pipeline at the same namespace id.
-3. **Wire the loaders to the real binding (server-only).** ⚠️ Not yet done — this is the
-   one piece that needs a live KV to verify, so it's intentionally deferred:
-   - TanStack loaders run on **both** server and client; KV is server-only. Wrap the
-     `src/data` getters in `createServerFn` (or convert the route loaders to server-only)
-     so KV reads always execute on the Worker, even on client-side navigation.
-   - Access the binding via the Cloudflare env in that server boundary and pass it to
-     `getStore(env)` (already supported in `src/data/store.ts`).
-   - Until this is wired, prod would serve the dev fixture — so do this before the DNS cutover.
-4. **Deploy:** `npm run deploy` (wrangler).
-5. **Custom domain:** map `iptv.shriramkraja.com` to the Worker in the Cloudflare dashboard
-   (Workers → Triggers → Custom Domains). Hard-capped free tier; no surprise bill.
-6. **Cache:** add an edge cache TTL (~12–24h) aligned to the pipeline's purge hook so KV
+2. **Seed it** — the pipeline publishes to KV when its CF secrets are set
+   (`pipeline/src/publish-kv.js` + the daily / EPG workflows); point them at the same namespace id.
+3. **Deploy:** `npm run deploy` (wrangler). Then verify a real page (e.g. `/country/gb`) serves
+   the KV snapshot, not the fixture — the one check that needs the live namespace.
+4. **Custom domain:** map `iptv.shriramkraja.com` to the Worker (Workers → Triggers → Custom
+   Domains). Hard-capped free tier; no surprise bill.
+5. **Cache:** add an edge cache TTL (~12–24h) aligned to the pipeline's purge hook so KV
    refreshes propagate without a redeploy.
 
 ## Coexistence

--- a/app/package.json
+++ b/app/package.json
@@ -11,7 +11,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",
-    "deploy": "npm run build && wrangler deploy"
+    "deploy": "npm run build && wrangler deploy",
+    "cf-typegen": "wrangler types"
   },
   "dependencies": {
     "@cloudflare/vite-plugin": "^1.26.0",

--- a/app/src/cloudflare-workers.d.ts
+++ b/app/src/cloudflare-workers.d.ts
@@ -1,0 +1,10 @@
+// Minimal ambient type for the `cloudflare:workers` virtual module (resolved at
+// build time by @cloudflare/vite-plugin; aliased to a stub in tests). Kept small
+// and self-contained so tsc works without committing the ~550KB `wrangler types`
+// output — run `npm run cf-typegen` for the full generated Cloudflare runtime types.
+declare module 'cloudflare:workers' {
+  export const env: {
+    SNAPSHOT_KV?: { get(key: string): Promise<string | null> }
+    [key: string]: unknown
+  }
+}

--- a/app/src/components/ChannelRail.test.tsx
+++ b/app/src/components/ChannelRail.test.tsx
@@ -2,14 +2,19 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor, cleanup } from '@testing-library/react'
 import { ChannelRail } from './ChannelRail'
 
-// Plain-anchor Link (no router) and a controlled channel index (via the server fn).
+// Plain-anchor Link (no router) and a controlled id→entry resolver (the server fn,
+// which returns only the requested ids).
 vi.mock('@tanstack/react-router', () => ({ Link: ({ children, ...p }: any) => <a {...p}>{children}</a> }))
-vi.mock('../data/server', () => ({
-  fetchChannelIndex: async () => ({
+vi.mock('../data/server', () => {
+  const ALL: Record<string, any> = {
     'BBCNews.uk': { country: 'gb', categories: ['news'], name: 'BBC News' },
     'NDTV.in': { country: 'in', categories: ['news'], name: 'NDTV 24x7' },
-  }),
-}))
+  }
+  return {
+    fetchChannelsByIds: async ({ data: ids }: { data: string[] }) =>
+      Object.fromEntries(ids.filter((id) => ALL[id]).map((id) => [id, ALL[id]])),
+  }
+})
 const rc = vi.hoisted(() => ({ killed: new Set<string>() }))
 vi.mock('../lib/useRemoteConfig', () => ({ useRemoteConfig: () => ({ announcement: '', killed: rc.killed, collections: [] }) }))
 

--- a/app/src/components/ChannelRail.test.tsx
+++ b/app/src/components/ChannelRail.test.tsx
@@ -2,10 +2,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor, cleanup } from '@testing-library/react'
 import { ChannelRail } from './ChannelRail'
 
-// Plain-anchor Link (no router) and a controlled channel index.
+// Plain-anchor Link (no router) and a controlled channel index (via the server fn).
 vi.mock('@tanstack/react-router', () => ({ Link: ({ children, ...p }: any) => <a {...p}>{children}</a> }))
-vi.mock('../data/kv', () => ({
-  getChannelIndex: async () => ({
+vi.mock('../data/server', () => ({
+  fetchChannelIndex: async () => ({
     'BBCNews.uk': { country: 'gb', categories: ['news'], name: 'BBC News' },
     'NDTV.in': { country: 'in', categories: ['news'], name: 'NDTV 24x7' },
   }),

--- a/app/src/data/server.ts
+++ b/app/src/data/server.ts
@@ -7,24 +7,40 @@ import { createServerFn } from '@tanstack/react-start'
 import { env } from 'cloudflare:workers'
 import { getStore, type AppEnv } from './store'
 import { getCategory, getChannel, getChannelIndex, getCountry, getEpgMeta, getEpgShard } from './kv'
-import type { EpgShard } from './types'
+import type { ChannelIndex, EpgShard } from './types'
 
 // getStore ignores env under `vite dev` (returns the fixture); in the built Worker
 // it reads the KV binding. `env` is a per-isolate proxy resolved per request here.
 const store = () => getStore(env as unknown as AppEnv)
 
-export const fetchHomeData = createServerFn({ method: 'GET' }).handler(async () => {
-  const index = await getChannelIndex(store())
+/** Distinct, alphabetically-sorted country codes + category slugs across the index. */
+function deriveFacets(index: ChannelIndex): { countries: string[]; categories: string[] } {
   const countries = new Set<string>()
   const categories = new Set<string>()
   for (const entry of Object.values(index)) {
     if (entry.country) countries.add(entry.country)
     for (const c of entry.categories) categories.add(c)
   }
-  return { countries: [...countries].sort(), categories: [...categories].sort(), total: Object.keys(index).length }
+  return { countries: [...countries].sort(), categories: [...categories].sort() }
+}
+
+export const fetchHomeData = createServerFn({ method: 'GET' }).handler(async () => {
+  const index = await getChannelIndex(store())
+  return { ...deriveFacets(index), total: Object.keys(index).length }
 })
 
 export const fetchChannelIndex = createServerFn({ method: 'GET' }).handler(async () => getChannelIndex(store()))
+
+/** Resolve only the requested channel ids → their index entries (small payload for
+ *  the client rails, rather than shipping the whole index). */
+export const fetchChannelsByIds = createServerFn({ method: 'GET' })
+  .inputValidator((ids: string[]) => ids)
+  .handler(async ({ data: ids }) => {
+    const index = await getChannelIndex(store())
+    const out: ChannelIndex = {}
+    for (const id of ids) if (index[id]) out[id] = index[id]
+    return out
+  })
 
 export const fetchCountryData = createServerFn({ method: 'GET' })
   .inputValidator((code: string) => code)
@@ -43,7 +59,8 @@ export const fetchCategoryData = createServerFn({ method: 'GET' })
 
     // EPG is sharded per country; only fetch shards for covered countries (avoids
     // pointless reads and keeps category coverage from being diluted by EPG-less ones).
-    const covered = new Set([...new Set(refs.map((r) => r.country))].filter((c) => epgMeta?.coverage[c] != null))
+    const covered = new Set<string>()
+    for (const r of refs) if (epgMeta?.coverage[r.country] != null) covered.add(r.country)
     const countries = [...covered]
     const shards = await Promise.all(countries.map((c) => getEpgShard(s, c)))
     const byCountry: Record<string, EpgShard> = Object.fromEntries(countries.map((c, i) => [c, shards[i]]))
@@ -72,12 +89,9 @@ export const fetchSearchData = createServerFn({ method: 'GET' })
   .handler(async ({ data: rawQ }) => {
     const q = rawQ.trim().toLowerCase()
     const index = await getChannelIndex(store())
-    const countries = new Set<string>()
-    const categories = new Set<string>()
+    const facets = deriveFacets(index) // shared, sorted — same ordering as home
     const channels: { id: string; name: string; country: string }[] = []
     for (const [id, entry] of Object.entries(index)) {
-      if (entry.country) countries.add(entry.country)
-      for (const c of entry.categories) categories.add(c)
       if (q && (entry.name.toLowerCase().includes(q) || id.toLowerCase().includes(q))) {
         channels.push({ id, name: entry.name, country: entry.country })
       }
@@ -85,7 +99,7 @@ export const fetchSearchData = createServerFn({ method: 'GET' })
     return {
       q: rawQ,
       channels,
-      countries: q ? [...countries].filter((c) => c.includes(q)) : [],
-      categories: q ? [...categories].filter((c) => c.toLowerCase().includes(q)) : [],
+      countries: q ? facets.countries.filter((c) => c.includes(q)) : [],
+      categories: q ? facets.categories.filter((c) => c.toLowerCase().includes(q)) : [],
     }
   })

--- a/app/src/data/server.ts
+++ b/app/src/data/server.ts
@@ -1,0 +1,91 @@
+// Server-only data boundary. All Cloudflare KV reads run here, inside createServerFn
+// handlers, so the KV binding (env.SNAPSHOT_KV) and the `cloudflare:workers` import
+// never reach the client bundle — the Start Vite plugin strips server-fn bodies
+// client-side. Route loaders and the client index hook call these fns; on client-
+// side navigation the call becomes an RPC to the Worker. See app/DEPLOY.md.
+import { createServerFn } from '@tanstack/react-start'
+import { env } from 'cloudflare:workers'
+import { getStore, type AppEnv } from './store'
+import { getCategory, getChannel, getChannelIndex, getCountry, getEpgMeta, getEpgShard } from './kv'
+import type { EpgShard } from './types'
+
+// getStore ignores env under `vite dev` (returns the fixture); in the built Worker
+// it reads the KV binding. `env` is a per-isolate proxy resolved per request here.
+const store = () => getStore(env as unknown as AppEnv)
+
+export const fetchHomeData = createServerFn({ method: 'GET' }).handler(async () => {
+  const index = await getChannelIndex(store())
+  const countries = new Set<string>()
+  const categories = new Set<string>()
+  for (const entry of Object.values(index)) {
+    if (entry.country) countries.add(entry.country)
+    for (const c of entry.categories) categories.add(c)
+  }
+  return { countries: [...countries].sort(), categories: [...categories].sort(), total: Object.keys(index).length }
+})
+
+export const fetchChannelIndex = createServerFn({ method: 'GET' }).handler(async () => getChannelIndex(store()))
+
+export const fetchCountryData = createServerFn({ method: 'GET' })
+  .inputValidator((code: string) => code)
+  .handler(async ({ data: code }) => {
+    const s = store()
+    const [channels, epg, epgMeta] = await Promise.all([getCountry(s, code), getEpgShard(s, code), getEpgMeta(s)])
+    return { code, channels, epg, epgMeta }
+  })
+
+export const fetchCategoryData = createServerFn({ method: 'GET' })
+  .inputValidator((slug: string) => slug)
+  .handler(async ({ data: slug }) => {
+    const s = store()
+    const [refs, index, epgMeta] = await Promise.all([getCategory(s, slug), getChannelIndex(s), getEpgMeta(s)])
+    const items = refs.map((r) => ({ id: r.id, country: r.country, name: index[r.id]?.name ?? r.id }))
+
+    // EPG is sharded per country; only fetch shards for covered countries (avoids
+    // pointless reads and keeps category coverage from being diluted by EPG-less ones).
+    const covered = new Set([...new Set(refs.map((r) => r.country))].filter((c) => epgMeta?.coverage[c] != null))
+    const countries = [...covered]
+    const shards = await Promise.all(countries.map((c) => getEpgShard(s, c)))
+    const byCountry: Record<string, EpgShard> = Object.fromEntries(countries.map((c, i) => [c, shards[i]]))
+    const epg: EpgShard = {}
+    for (const r of refs) {
+      const sched = byCountry[r.country]?.[r.id]
+      if (sched) epg[r.id] = sched
+    }
+    const relevant = items.filter((it) => covered.has(it.country))
+    const coverage = relevant.length ? Object.keys(epg).length / relevant.length : 0
+    return { slug, items, epg, epgMeta, coverage }
+  })
+
+export const fetchChannelData = createServerFn({ method: 'GET' })
+  .inputValidator((id: string) => id)
+  .handler(async ({ data: id }) => {
+    const s = store()
+    const channel = await getChannel(s, id)
+    if (!channel) return { channel: null, schedule: null }
+    const schedule = channel.country ? (await getEpgShard(s, channel.country))[channel.id] : undefined
+    return { channel, schedule: schedule ?? null }
+  })
+
+export const fetchSearchData = createServerFn({ method: 'GET' })
+  .inputValidator((q: string) => q)
+  .handler(async ({ data: rawQ }) => {
+    const q = rawQ.trim().toLowerCase()
+    const index = await getChannelIndex(store())
+    const countries = new Set<string>()
+    const categories = new Set<string>()
+    const channels: { id: string; name: string; country: string }[] = []
+    for (const [id, entry] of Object.entries(index)) {
+      if (entry.country) countries.add(entry.country)
+      for (const c of entry.categories) categories.add(c)
+      if (q && (entry.name.toLowerCase().includes(q) || id.toLowerCase().includes(q))) {
+        channels.push({ id, name: entry.name, country: entry.country })
+      }
+    }
+    return {
+      q: rawQ,
+      channels,
+      countries: q ? [...countries].filter((c) => c.includes(q)) : [],
+      categories: q ? [...categories].filter((c) => c.toLowerCase().includes(q)) : [],
+    }
+  })

--- a/app/src/data/store.ts
+++ b/app/src/data/store.ts
@@ -1,14 +1,21 @@
-// Pick the snapshot store: the Cloudflare KV binding when present (prod / wrangler
-// dev with a seeded namespace), otherwise the bundled fixture (local dev + tests).
+// Pick the snapshot store: the Cloudflare KV binding in production, otherwise the
+// bundled fixture (local dev + tests). Kept free of any `cloudflare:workers` import
+// so it stays isomorphic — the binding is passed in from the server-only boundary
+// (src/data/server.ts). See app/DEPLOY.md.
 import { kvStore, type SnapshotStore } from './kv'
 import { fixtureStore } from './fixture'
 
 export interface AppEnv {
-  // Cloudflare KV binding the pipeline publishes to (added in wrangler.jsonc, U9).
+  // Cloudflare KV binding the pipeline publishes to (wrangler.jsonc SNAPSHOT_KV).
   SNAPSHOT_KV?: { get(key: string): Promise<string | null> }
 }
 
 export function getStore(env?: AppEnv): SnapshotStore {
+  // Dev/test always use the bundled fixture — the Cloudflare Vite plugin provides a
+  // real-but-EMPTY Miniflare KV binding in `vite dev`, so gating on binding presence
+  // would serve empty data locally. `import.meta.env.DEV` is inlined by Vite (true
+  // under dev, false in the built Worker), so this is safe on both server and client.
+  if (import.meta.env.DEV) return fixtureStore()
   if (env?.SNAPSHOT_KV) return kvStore(env.SNAPSHOT_KV)
-  return fixtureStore()
+  return fixtureStore() // prod safety net before the KV namespace is seeded
 }

--- a/app/src/lib/useResolvedChannels.ts
+++ b/app/src/lib/useResolvedChannels.ts
@@ -1,14 +1,15 @@
 import { useEffect, useState } from 'react'
-import { fetchChannelIndex } from '../data/server'
+import { fetchChannelsByIds } from '../data/server'
 import type { Channel, ChannelIndex } from '../data/types'
 
-// Resolve a list of channel IDs (favorites, history, featured) to Channel records
-// via the channel index — client-only, since the IDs come from localStorage /
-// Remote Config. Shared by the home rails and the /favorites page so the id→Channel
-// contract lives in one place. Returns `loading` until the index resolves.
+// Resolve a list of channel IDs (favorites, history, featured) to Channel records —
+// client-only, since the IDs come from localStorage / Remote Config. Shared by the
+// home rails and the /favorites page so the id→Channel contract lives in one place.
 //
-// The index is fetched through the `fetchChannelIndex` server function (a Worker
-// RPC on the client), so KV stays server-only — the client never reads the binding.
+// Resolves through the `fetchChannelsByIds` server fn (a Worker RPC on the client)
+// so KV stays server-only AND only the requested entries cross the wire (not the
+// whole index). Any RPC failure resolves to empty — the rail just renders nothing
+// rather than spinning forever.
 
 /** Minimal Channel from an index entry — enough for a card (no streams/logo). */
 function toChannel(id: string, entry: ChannelIndex[string]): Channel {
@@ -16,19 +17,21 @@ function toChannel(id: string, entry: ChannelIndex[string]): Channel {
 }
 
 export function useResolvedChannels(ids: string[]): { channels: Channel[]; loading: boolean } {
-  const [index, setIndex] = useState<ChannelIndex | null>(null)
+  const [resolved, setResolved] = useState<ChannelIndex | null>(null)
+  const key = ids.join(',') // re-resolve when the id set changes (e.g. a new favorite)
   useEffect(() => {
     let cancelled = false
-    fetchChannelIndex().then((idx) => {
-      if (!cancelled) setIndex(idx)
-    })
+    fetchChannelsByIds({ data: ids })
+      .then((idx) => !cancelled && setResolved(idx))
+      .catch(() => !cancelled && setResolved({})) // failure → empty, never hang
     return () => {
       cancelled = true
     }
-  }, [])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key])
 
-  const channels = index
-    ? ids.map((id) => (index[id] ? toChannel(id, index[id]) : null)).filter((c): c is Channel => c !== null)
+  const channels = resolved
+    ? ids.map((id) => (resolved[id] ? toChannel(id, resolved[id]) : null)).filter((c): c is Channel => c !== null)
     : []
-  return { channels, loading: index === null }
+  return { channels, loading: resolved === null }
 }

--- a/app/src/lib/useResolvedChannels.ts
+++ b/app/src/lib/useResolvedChannels.ts
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react'
-import { getStore } from '../data/store'
-import { getChannelIndex } from '../data/kv'
+import { fetchChannelIndex } from '../data/server'
 import type { Channel, ChannelIndex } from '../data/types'
 
 // Resolve a list of channel IDs (favorites, history, featured) to Channel records
@@ -8,8 +7,8 @@ import type { Channel, ChannelIndex } from '../data/types'
 // Remote Config. Shared by the home rails and the /favorites page so the id→Channel
 // contract lives in one place. Returns `loading` until the index resolves.
 //
-// Note: relies on the channel index being readable client-side (true today via the
-// bundled fixture; the KV cutover — app/DEPLOY.md — must keep it client-accessible).
+// The index is fetched through the `fetchChannelIndex` server function (a Worker
+// RPC on the client), so KV stays server-only — the client never reads the binding.
 
 /** Minimal Channel from an index entry — enough for a card (no streams/logo). */
 function toChannel(id: string, entry: ChannelIndex[string]): Channel {
@@ -20,7 +19,7 @@ export function useResolvedChannels(ids: string[]): { channels: Channel[]; loadi
   const [index, setIndex] = useState<ChannelIndex | null>(null)
   useEffect(() => {
     let cancelled = false
-    getChannelIndex(getStore()).then((idx) => {
+    fetchChannelIndex().then((idx) => {
       if (!cancelled) setIndex(idx)
     })
     return () => {

--- a/app/src/routes/category.$slug.tsx
+++ b/app/src/routes/category.$slug.tsx
@@ -1,38 +1,11 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
-import { getStore } from '../data/store'
-import { getCategory, getChannelIndex, getEpgShard, getEpgMeta } from '../data/kv'
+import { fetchCategoryData } from '../data/server'
 import { LiveNowBoard } from '../components/LiveNowBoard'
 import { StructuredData } from '../components/StructuredData'
 import { useRemoteConfig } from '../lib/useRemoteConfig'
-import type { EpgShard } from '../data/types'
 
 export const Route = createFileRoute('/category/$slug')({
-  loader: async ({ params }) => {
-    const store = getStore()
-    const [refs, index, epgMeta] = await Promise.all([getCategory(store, params.slug), getChannelIndex(store), getEpgMeta(store)])
-    const items = refs.map((r) => ({ id: r.id, country: r.country, name: index[r.id]?.name ?? r.id }))
-
-    // EPG is sharded per country; a category spans countries. Only fetch shards
-    // for countries that actually have EPG coverage (per epg-meta) — avoids N
-    // pointless KV reads for EPG-less countries on a broad category, and keeps
-    // category coverage from being diluted by those countries (which would hide
-    // the board even when the covered slice is airing).
-    const covered = new Set(
-      [...new Set(refs.map((r) => r.country))].filter((c) => epgMeta?.coverage[c] != null),
-    )
-    const countries = [...covered]
-    const shards = await Promise.all(countries.map((c) => getEpgShard(store, c)))
-    const byCountry: Record<string, EpgShard> = Object.fromEntries(countries.map((c, i) => [c, shards[i]]))
-    const epg: EpgShard = {}
-    for (const r of refs) {
-      const sched = byCountry[r.country]?.[r.id]
-      if (sched) epg[r.id] = sched
-    }
-    // Coverage denominator = this category's channels in covered countries only.
-    const relevant = items.filter((it) => covered.has(it.country))
-    const coverage = relevant.length ? Object.keys(epg).length / relevant.length : 0
-    return { slug: params.slug, items, epg, epgMeta, coverage }
-  },
+  loader: async ({ params }) => fetchCategoryData({ data: params.slug }),
   head: ({ params }) => ({ meta: [{ title: `${params.slug} channels — free live TV guide` }] }),
   component: CategoryPage,
 })

--- a/app/src/routes/channel.$id.tsx
+++ b/app/src/routes/channel.$id.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute, Link, notFound } from '@tanstack/react-router'
-import { getStore } from '../data/store'
-import { getChannel, getEpgShard } from '../data/kv'
+import { fetchChannelData } from '../data/server'
 import { Player } from '../components/Player'
 import { StructuredData } from '../components/StructuredData'
 import { useEffect } from 'react'
@@ -13,13 +12,9 @@ import { broadcastEvents } from '../lib/jsonld'
 
 export const Route = createFileRoute('/channel/$id')({
   loader: async ({ params }) => {
-    const store = getStore()
-    const channel = await getChannel(store, params.id)
-    if (!channel) throw notFound()
-    // EPG schedule (absolute UTC times) fetched server-side; now/next is computed
-    // client-side. Absent country/coverage → empty → labels silently omitted.
-    const schedule = channel.country ? (await getEpgShard(store, channel.country))[channel.id] : undefined
-    return { channel, schedule: schedule ?? null }
+    const data = await fetchChannelData({ data: params.id })
+    if (!data.channel) throw notFound()
+    return { channel: data.channel, schedule: data.schedule }
   },
   head: ({ loaderData }) => ({
     meta: [{ title: loaderData ? `${loaderData.channel.name} — watch live` : 'Channel' }],

--- a/app/src/routes/country.$code.tsx
+++ b/app/src/routes/country.$code.tsx
@@ -1,21 +1,12 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
-import { getStore } from '../data/store'
-import { getCountry, getEpgShard, getEpgMeta } from '../data/kv'
+import { fetchCountryData } from '../data/server'
 import { ChannelCard } from '../components/ChannelCard'
 import { LiveNowBoard } from '../components/LiveNowBoard'
 import { StructuredData } from '../components/StructuredData'
 import { useRemoteConfig } from '../lib/useRemoteConfig'
 
 export const Route = createFileRoute('/country/$code')({
-  loader: async ({ params }) => {
-    const store = getStore()
-    const [channels, epg, epgMeta] = await Promise.all([
-      getCountry(store, params.code),
-      getEpgShard(store, params.code),
-      getEpgMeta(store),
-    ])
-    return { code: params.code, channels, epg, epgMeta }
-  },
+  loader: async ({ params }) => fetchCountryData({ data: params.code }),
   head: ({ params }) => ({
     meta: [{ title: `Live TV channels in ${params.code.toUpperCase()} — free streaming guide` }],
   }),

--- a/app/src/routes/index.tsx
+++ b/app/src/routes/index.tsx
@@ -1,25 +1,11 @@
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
-import { getStore } from '../data/store'
-import { getChannelIndex } from '../data/kv'
+import { fetchHomeData } from '../data/server'
 import { ChannelRail } from '../components/ChannelRail'
 import { useFavorites, useHistory } from '../lib/useEngagement'
 import { useRemoteConfig } from '../lib/useRemoteConfig'
 
 export const Route = createFileRoute('/')({
-  loader: async () => {
-    const index = await getChannelIndex(getStore())
-    const countries = new Set<string>()
-    const categories = new Set<string>()
-    for (const entry of Object.values(index)) {
-      if (entry.country) countries.add(entry.country)
-      for (const c of entry.categories) categories.add(c)
-    }
-    return {
-      countries: [...countries].sort(),
-      categories: [...categories].sort(),
-      total: Object.keys(index).length,
-    }
-  },
+  loader: async () => fetchHomeData(),
   head: () => ({ meta: [{ title: 'Free Live TV — browse channels by country & category' }] }),
   component: Home,
 })

--- a/app/src/routes/search.tsx
+++ b/app/src/routes/search.tsx
@@ -1,31 +1,11 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
-import { getStore } from '../data/store'
-import { getChannelIndex } from '../data/kv'
+import { fetchSearchData } from '../data/server'
 import { useRemoteConfig } from '../lib/useRemoteConfig'
 
 export const Route = createFileRoute('/search')({
   validateSearch: (search: Record<string, unknown>) => ({ q: String(search.q ?? '') }),
   loaderDeps: ({ search }) => ({ q: search.q }),
-  loader: async ({ deps }) => {
-    const q = deps.q.trim().toLowerCase()
-    const index = await getChannelIndex(getStore())
-    const countries = new Set<string>()
-    const categories = new Set<string>()
-    const channels: { id: string; name: string; country: string }[] = []
-    for (const [id, entry] of Object.entries(index)) {
-      if (entry.country) countries.add(entry.country)
-      for (const c of entry.categories) categories.add(c)
-      if (q && (entry.name.toLowerCase().includes(q) || id.toLowerCase().includes(q))) {
-        channels.push({ id, name: entry.name, country: entry.country })
-      }
-    }
-    return {
-      q: deps.q,
-      channels,
-      countries: q ? [...countries].filter((c) => c.includes(q)) : [],
-      categories: q ? [...categories].filter((c) => c.toLowerCase().includes(q)) : [],
-    }
-  },
+  loader: async ({ deps }) => fetchSearchData({ data: deps.q }),
   head: ({ loaderData }) => ({ meta: [{ title: loaderData?.q ? `Search: ${loaderData.q}` : 'Search' }] }),
   component: SearchPage,
 })

--- a/app/src/routes/sitemap[.]xml.tsx
+++ b/app/src/routes/sitemap[.]xml.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { getStore } from '../data/store'
-import { getChannelIndex } from '../data/kv'
+import { fetchChannelIndex } from '../data/server'
 import { buildSitemap } from '../lib/sitemap'
 
 export const Route = createFileRoute('/sitemap.xml')({
@@ -8,7 +7,7 @@ export const Route = createFileRoute('/sitemap.xml')({
     handlers: {
       GET: async ({ request }: { request: Request }) => {
         const origin = new URL(request.url).origin
-        const xml = buildSitemap(origin, await getChannelIndex(getStore()))
+        const xml = buildSitemap(origin, await fetchChannelIndex())
         return new Response(xml, {
           headers: { 'content-type': 'application/xml; charset=utf-8', 'cache-control': 'public, max-age=3600' },
         })

--- a/app/src/test/cloudflare-workers-stub.ts
+++ b/app/src/test/cloudflare-workers-stub.ts
@@ -1,0 +1,6 @@
+// Test-only stub for the `cloudflare:workers` virtual module (which only exists in
+// the workerd/Vite-plugin runtime). Vitest aliases the import here so modules that
+// reference `env` (src/data/server.ts) can be imported under jsdom without failing
+// to resolve. In tests the fixture path is used anyway (import.meta.env.DEV), so
+// this env is never actually read for data.
+export const env = {} as Record<string, unknown>

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -1,9 +1,17 @@
 import { defineConfig } from 'vitest/config'
+import { fileURLToPath } from 'node:url'
 
 // Unit/component tests run in a plain jsdom environment — NOT through the
 // Cloudflare workers runtime (vite.config.ts's cloudflare() plugin is for the
 // app build/serve, not for unit tests).
 export default defineConfig({
+  resolve: {
+    alias: {
+      // The `cloudflare:workers` virtual module only exists in workerd; stub it so
+      // modules that import `env` (src/data/server.ts) load under jsdom.
+      'cloudflare:workers': fileURLToPath(new URL('./src/test/cloudflare-workers-stub.ts', import.meta.url)),
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## What & why

The go-live prerequisite (`app/DEPLOY.md`): the v2 app read a **bundled fixture everywhere** — even server-side — so production would serve the dev fixture, not the real pipeline snapshot. This wires **server-only Cloudflare KV reads** while keeping the zero-setup fixture for local dev.

## How it works

- **`src/data/server.ts` (new)** — `createServerFn` wrappers hold every KV read (`fetchHomeData`, `fetchCountryData`, `fetchCategoryData`, `fetchChannelData`, `fetchSearchData`, `fetchChannelIndex`, `fetchChannelsByIds`). **Only this file imports `env` from `cloudflare:workers`**; the TanStack Start Vite plugin strips server-fn bodies from the client bundle, so the KV binding never reaches the browser.
- **Loaders + sitemap** call those server fns; on client-side navigation they become Worker RPCs, so KV always runs server-side.
- **`useResolvedChannels`** (favorites / recently-watched / featured rails) resolves ids through `fetchChannelsByIds` — a Worker RPC that returns **only the requested entries**, not the whole index.
- **`store.ts`** gates the fixture on `import.meta.env.DEV` — the key gotcha: the Cloudflare Vite plugin gives `vite dev` a real-but-**empty** Miniflare KV binding, so gating on binding-presence would serve empty data locally. Dev/test → fixture; the built Worker → `SNAPSHOT_KV`.
- **Types**: a tiny ambient decl for `cloudflare:workers` (`src/cloudflare-workers.d.ts`) so tsc works without committing the ~550 KB `wrangler types` output; `npm run cf-typegen` regenerates the full types (gitignored). Vitest aliases `cloudflare:workers` to a stub.

## Testing

- **101 app tests pass**; tsc clean (apart from a pre-existing Start server-route typing gap on the sitemap route).
- **Build-verified boundary**: `cloudflare:workers` / `SNAPSHOT_KV` appear in **0** client-bundle files and only in the server bundle.
- **Browser-verified (dev, through the new server-fn loaders)**: `/country/in` renders the board + cards, a channel page renders, a missing channel returns **404** (correct for crawlers), the sitemap serves XML, and the favorites/rails resolve via the `fetchChannelsByIds` RPC — zero console errors.

## Review

High-effort multi-agent review. **Fixed** the RPC-switch regressions: `useResolvedChannels` now has an error branch (an RPC failure resolves to empty instead of spinning "Loading…" forever) and fetches **only the requested ids** rather than the multi-MB index per rail; `fetchSearchData` reuses a shared **sorted** `deriveFacets` (search chips were unsorted vs home); simplified a redundant double-Set.

### Accepted by design (documented)
- **`store.ts` dev=fixture / prod=KV gate** — intentional so `vite dev` needs zero Cloudflare setup (Miniflare's empty binding would otherwise serve empty data). To test against real KV, deploy to a preview.
- **Fixture safety-net + unseeded-KV window** — if the binding is missing, prod soft-fails to the fixture (site stays up) rather than erroring; if the namespace is declared but unseeded, the site is empty until the pipeline publishes. Both are handled by the runbook order (**seed before deploy**, strengthened in DEPLOY.md).

## Post-Deploy Monitoring & Validation

The remaining steps need **your Cloudflare account** and are the one thing not verifiable here (no live namespace) — documented in `app/DEPLOY.md`: (1) `wrangler kv namespace create SNAPSHOT_KV` + paste the id into `wrangler.jsonc`; (2) point the pipeline at that namespace and let it publish; (3) `npm run deploy`, then confirm `/country/gb` serves the KV snapshot (not the fixture); (4) custom domain + edge cache TTL. Rollback = revert (dev/fixture unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
