### PR TITLE
fix(pipeline): persist snapshot baseline on unprotected pipeline-state branch

### DIFF
--- a/.github/workflows/v2-pipeline.yml
+++ b/.github/workflows/v2-pipeline.yml
@@ -23,6 +23,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # The diff baseline (last published snapshot) lives on the machine-owned,
+      # unprotected `pipeline-state` branch — NOT master, which stays PR-protected and
+      # free of daily machine commits. Restore it into the working tree so the pipeline
+      # can diff the fresh snapshot against what's currently live.
+      - name: Restore snapshot baseline from pipeline-state
+        run: |
+          if git fetch origin pipeline-state 2>/dev/null; then
+            git checkout FETCH_HEAD -- data/ 2>/dev/null && echo "baseline restored from pipeline-state" \
+              || echo "pipeline-state has no data/ yet"
+          else
+            echo "no pipeline-state branch yet — first run, empty baseline"
+          fi
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -40,26 +53,19 @@ jobs:
           CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
         run: npm run pipeline
 
-      # Normal / fast-pathed diff → auto-commit the snapshot to the default branch
-      # (KV was already published by the pipeline step). origin R6/R12.
-      - name: Commit snapshot (normal)
+      # Normal / fast-pathed diff → persist the refreshed snapshot as the new baseline
+      # on the unprotected `pipeline-state` branch (KV was already published above).
+      # master is never written to, so its PR protection is fully preserved. origin R6/R12.
+      - name: Persist snapshot baseline to pipeline-state
         if: steps.pipeline.outputs.action == 'published'
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git add data/snapshot data/pipeline-state.json
-          if git diff-index --quiet HEAD --; then
-            echo "No snapshot changes."
-          else
-            git commit -m "chore(pipeline): daily snapshot refresh"
-            # The repo receives other automated commits; rebase + retry so a
-            # non-fast-forward push doesn't leave KV ahead of the committed baseline.
-            for attempt in 1 2 3; do
-              git pull --rebase --autostash origin "$(git rev-parse --abbrev-ref HEAD)" || true
-              if git push; then break; fi
-              echo "push attempt $attempt failed; retrying"; sleep 5
-            done
-          fi
+          # data/ is untracked on master; stage the fresh snapshot explicitly and
+          # force-push it as the sole content of the machine-owned pipeline-state branch.
+          git add -f data/snapshot data/pipeline-state.json
+          git commit -m "chore(pipeline): snapshot baseline refresh"
+          git push --force origin HEAD:refs/heads/pipeline-state
 
       # Anomaly diff → open a review PR; do NOT publish (prior snapshot stays live).
       # origin R7.

--- a/app/DEPLOY.md
+++ b/app/DEPLOY.md
@@ -31,22 +31,32 @@ client bundle, even on client-side navigation:
 - Types: `cloudflare:workers` has a minimal ambient decl (`src/cloudflare-workers.d.ts`); run
   `npm run cf-typegen` for the full generated Cloudflare runtime types (gitignored).
 
-## Going live (remaining ops — needs a Cloudflare account + a live KV)
+## Live (✅ deployed)
 
-1. **Create the KV namespace** and paste its id into `wrangler.jsonc` (`SNAPSHOT_KV`, currently
-   `REPLACE_WITH_KV_NAMESPACE_ID`):
+- **URL:** https://iptv.shriramkraja.com (Cloudflare Worker `iptv-viewer-v2`, custom domain + auto TLS).
+- **KV namespace `SNAPSHOT_KV`** = `e0ac905d8fc74bc0a5d0c192786e677d` (in `wrangler.jsonc`).
+- **Freshness:** the `v2 data pipeline` (daily) + `v2 EPG refresh` (6-hourly) Actions publish to KV;
+  they authenticate via the repo secrets `CF_API_TOKEN` / `CF_ACCOUNT_ID` / `CF_KV_NAMESPACE_ID`.
+
+### How the pipeline persists its diff baseline
+The pipeline diffs each new snapshot against the last published one to decide auto-publish vs
+anomaly-review. That baseline is kept on a dedicated, **unprotected `pipeline-state` branch** — the
+workflow restores `data/` from it before a run and force-pushes the refreshed `data/` back after.
+`master` is never written to by the bot, so it stays PR-protected and free of daily machine commits.
+`data/` is therefore a machine artifact; don't commit it to `master`.
+
+### Original bring-up steps (for reference / a fresh environment)
+
+1. **Create the KV namespace** and paste its id into `wrangler.jsonc` (`SNAPSHOT_KV`):
    ```
    npx wrangler kv namespace create SNAPSHOT_KV
    ```
-2. **Seed it** — the pipeline publishes to KV when its CF secrets are set
-   (`pipeline/src/publish-kv.js` + the daily / EPG workflows); point them at the same namespace id.
-3. **Deploy:** `npm run deploy` (wrangler). Then verify a real page (e.g. `/country/gb`) serves
-   the KV snapshot, not the fixture — the one check that needs the live namespace.
-4. **Custom domain:** map `iptv.shriramkraja.com` to the Worker (Workers → Triggers → Custom
-   Domains). Hard-capped free tier; no surprise bill.
-5. **Cache:** add an edge cache TTL (~12–24h) aligned to the pipeline's purge hook so KV
-   refreshes propagate without a redeploy.
+2. **Seed it** — set the `CF_*` secrets (or env vars) and run `npm run pipeline` + `npm run epg`.
+3. **Deploy:** `npm run deploy` (wrangler). Verify `/country/gb` serves the KV snapshot, not the fixture.
+4. **Custom domain:** map the domain to the Worker (Workers → Settings → Domains & Routes).
+5. **Cache:** an edge cache TTL (~12–24h) aligned to the pipeline's purge hook lets KV refreshes
+   propagate without a redeploy.
 
 ## Coexistence
-The v1 CRA app at the repo root stays on GitHub Pages until this v2 app is verified live;
-the DNS cutover is the last step.
+The v1 CRA app at the repo root remains on GitHub Pages; v2 is the live site at
+`iptv.shriramkraja.com`.

--- a/app/wrangler.jsonc
+++ b/app/wrangler.jsonc
@@ -1,12 +1,20 @@
 {
-  "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "iptv-viewer-v2",
-  "compatibility_date": "2025-09-02",
-  "compatibility_flags": ["nodejs_compat"],
-  "main": "@tanstack/react-start/server-entry",
-  // KV namespace the data pipeline publishes the snapshot to (country:*, category:*,
-  // channel-index, meta). Create it with `wrangler kv namespace create SNAPSHOT_KV`
-  // and paste the returned id below. Until set, the app falls back to the bundled
-  // dev fixture (see src/data/store.ts).
-  "kv_namespaces": [{ "binding": "SNAPSHOT_KV", "id": "REPLACE_WITH_KV_NAMESPACE_ID" }]
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "iptv-viewer-v2",
+	"compatibility_date": "2025-09-02",
+	"compatibility_flags": [
+		"nodejs_compat"
+	],
+	"main": "@tanstack/react-start/server-entry",
+	// KV namespace the data pipeline publishes the snapshot to (country:*, category:*,
+	// channel-index, meta). `remote: true` lets `wrangler dev` on the built Worker read
+	// the real remote KV; `npm run dev` (vite) always uses the bundled fixture regardless
+	// (the import.meta.env.DEV gate in src/data/store.ts).
+	"kv_namespaces": [
+		{
+			"binding": "SNAPSHOT_KV",
+			"id": "e0ac905d8fc74bc0a5d0c192786e677d",
+			"remote": true
+		}
+	]
 }


### PR DESCRIPTION
## Problem

The `v2 data pipeline` workflow auto-committed its diff **baseline** (the last published snapshot in `data/`) to `master` and `git push`ed directly. But `master` requires a PR, so GitHub rejected even `github-actions[bot]`:

```
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote: - Changes must be made through a pull request.
```

So that step has **always failed** — `data/` never once landed on `master`. KV publishing still worked (the site stayed fresh), but the pipeline's **anomaly gate was effectively disabled** (it never had a baseline to diff against), and every run showed a red ❌.

Adding the Actions bot to the classic-protection bypass list isn't an option — the GitHub API returns **HTTP 500** for that, and the default `GITHUB_TOKEN` can't bypass "require a PR" on classic protection anyway.

## Fix (workflow-only — `pipeline/` untouched)

Keep the baseline on a dedicated, **unprotected `pipeline-state` branch** instead of `master`:

- **Before the run** — `Restore snapshot baseline from pipeline-state`: fetch that branch and check `data/` into the working tree, so the pipeline diffs against what's currently live. First run (no branch yet) → empty baseline, handled gracefully.
- **After a normal run** — `Persist snapshot baseline to pipeline-state`: force-push the refreshed `data/` to `pipeline-state`. `master` is never written to.

Result:
- ✅ `master` stays PR-protected **and** free of daily machine commits
- ✅ the anomaly gate finally has a real baseline (works run-to-run)
- ✅ workflow goes green — no more rejected pushes
- The anomaly path (`create-pull-request`) is unchanged; it still opens a review PR on the rare anomalous diff.

Also folded in (both were pending): the live **`SNAPSHOT_KV` namespace id** in `wrangler.jsonc` (was a placeholder — a fresh clone / CI deploy would've failed), and a **`DEPLOY.md`** refresh documenting the live URL + the `pipeline-state` baseline design.

## Testing / rollout

- YAML structure verified; `pipeline/` code and its tests are untouched (`test:pipeline` still runs first in the job).
- Can't fully exercise a GitHub-Actions git push from here — after merge, trigger **Actions → v2 data pipeline → Run workflow** once: it should go green, create the `pipeline-state` branch, and leave `master` untouched. KV keeps publishing exactly as it does today regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
