### PR TITLE
fix(app): cacheTtl on KV reads — stay within the free-tier daily limit

### DIFF
--- a/app/src/cloudflare-workers.d.ts
+++ b/app/src/cloudflare-workers.d.ts
@@ -4,7 +4,7 @@
 // output — run `npm run cf-typegen` for the full generated Cloudflare runtime types.
 declare module 'cloudflare:workers' {
   export const env: {
-    SNAPSHOT_KV?: { get(key: string): Promise<string | null> }
+    SNAPSHOT_KV?: { get(key: string, options?: { cacheTtl?: number }): Promise<string | null> }
     [key: string]: unknown
   }
 }

--- a/app/src/data/kv.ts
+++ b/app/src/data/kv.ts
@@ -5,18 +5,30 @@
 import { kvKeys } from './keys'
 import type { Channel, CategoryRef, ChannelIndex, Meta, EpgShard, EpgMeta } from './types'
 
-/** Minimal read surface both KV and the fixture satisfy. */
+// Edge cache TTLs (seconds) passed to KV `get` so a key read once is served from
+// the colo cache instead of a billed origin read on every request — the difference
+// between a crawler burning ~30k reads walking every channel page and a few hundred.
+// The pipeline republishes the catalog daily and EPG every ~6h, so this staleness is
+// safe: CATALOG_TTL caps how long a snapshot change takes to propagate; EPG uses a
+// shorter TTL so now/next stays fresh. (KV cacheTtl minimum is 60s.)
+const CATALOG_TTL = 21_600 // 6h — channel-index, country/category shards, meta
+const EPG_TTL = 3_600 // 1h — schedule shards + epg-meta
+
+/** Minimal read surface both KV and the fixture satisfy. `cacheTtl` is honored by
+ *  the KV binding and ignored by the fixture. */
 export interface SnapshotStore {
-  get(key: string): Promise<string | null>
+  get(key: string, cacheTtl?: number): Promise<string | null>
 }
 
 /** Wrap a Cloudflare KV namespace binding. */
-export function kvStore(binding: { get(key: string): Promise<string | null> }): SnapshotStore {
-  return { get: (key) => binding.get(key) }
+export function kvStore(binding: {
+  get(key: string, options?: { cacheTtl?: number }): Promise<string | null>
+}): SnapshotStore {
+  return { get: (key, cacheTtl) => binding.get(key, cacheTtl != null ? { cacheTtl } : undefined) }
 }
 
-async function readJson<T>(store: SnapshotStore, key: string): Promise<T | null> {
-  const raw = await store.get(key)
+async function readJson<T>(store: SnapshotStore, key: string, cacheTtl?: number): Promise<T | null> {
+  const raw = await store.get(key, cacheTtl)
   if (raw == null) return null
   try {
     return JSON.parse(raw) as T
@@ -26,19 +38,19 @@ async function readJson<T>(store: SnapshotStore, key: string): Promise<T | null>
 }
 
 export function getMeta(store: SnapshotStore) {
-  return readJson<Meta>(store, kvKeys.meta())
+  return readJson<Meta>(store, kvKeys.meta(), CATALOG_TTL)
 }
 
 export async function getCountry(store: SnapshotStore, code: string): Promise<Channel[]> {
-  return (await readJson<Channel[]>(store, kvKeys.country(code))) ?? []
+  return (await readJson<Channel[]>(store, kvKeys.country(code), CATALOG_TTL)) ?? []
 }
 
 export async function getCategory(store: SnapshotStore, slug: string): Promise<CategoryRef[]> {
-  return (await readJson<CategoryRef[]>(store, kvKeys.category(slug))) ?? []
+  return (await readJson<CategoryRef[]>(store, kvKeys.category(slug), CATALOG_TTL)) ?? []
 }
 
 export async function getChannelIndex(store: SnapshotStore): Promise<ChannelIndex> {
-  return (await readJson<ChannelIndex>(store, kvKeys.channelIndex())) ?? {}
+  return (await readJson<ChannelIndex>(store, kvKeys.channelIndex(), CATALOG_TTL)) ?? {}
 }
 
 /** Resolve a channel by id: index → its country shard → the full record. */
@@ -52,10 +64,10 @@ export async function getChannel(store: SnapshotStore, id: string): Promise<Chan
 
 /** One country's EPG schedule shard; `{}` when absent (silent degradation). */
 export async function getEpgShard(store: SnapshotStore, code: string): Promise<EpgShard> {
-  return (await readJson<EpgShard>(store, kvKeys.epg(code))) ?? {}
+  return (await readJson<EpgShard>(store, kvKeys.epg(code), EPG_TTL)) ?? {}
 }
 
 /** EPG coverage + config; null when EPG hasn't been published. */
 export function getEpgMeta(store: SnapshotStore): Promise<EpgMeta | null> {
-  return readJson<EpgMeta>(store, kvKeys.epgMeta())
+  return readJson<EpgMeta>(store, kvKeys.epgMeta(), EPG_TTL)
 }

--- a/app/src/data/store.ts
+++ b/app/src/data/store.ts
@@ -7,7 +7,8 @@ import { fixtureStore } from './fixture'
 
 export interface AppEnv {
   // Cloudflare KV binding the pipeline publishes to (wrangler.jsonc SNAPSHOT_KV).
-  SNAPSHOT_KV?: { get(key: string): Promise<string | null> }
+  // `get` takes an options bag so reads can pass `cacheTtl` (edge-cache the read).
+  SNAPSHOT_KV?: { get(key: string, options?: { cacheTtl?: number }): Promise<string | null> }
 }
 
 export function getStore(env?: AppEnv): SnapshotStore {


### PR DESCRIPTION
## Problem

Cloudflare alerted that the app hit **50% of the 100k/day Workers KV free-tier read limit**. Root cause: every request reads KV **from origin, uncached** — the home/search/channel pages each read `channel-index` (and channel pages also read a country shard + EPG shard). A crawler walking all ~10k channel pages (plus today's deploy testing) burns tens of thousands of reads; at 100% the KV API returns 429 and the site breaks until 00:00 UTC.

## Fix

Pass **`cacheTtl`** to the KV `get` calls so a key read once is served from the colo **edge cache** instead of a billed origin read on every request:

- **6h** (`CATALOG_TTL`) for the daily catalog — `channel-index`, country/category shards, `meta`.
- **1h** (`EPG_TTL`) for EPG shards + `epg-meta` — keeps now/next fresh.

The pipeline republishes the catalog daily and EPG every ~6h, so the bounded staleness is safe. A crawl that read ~30k times now reads each unique key ~once per TTL window (a few hundred origin reads total). No correctness change; `now/next` is still computed live client-side. Keeps the site on the **free tier — no upgrade needed**.

- `kvStore` forwards `cacheTtl` to the binding; the fixture ignores it (dev/test unaffected).
- Widened the `SNAPSHOT_KV` binding types (`store.ts` + `cloudflare-workers.d.ts`) to accept the options bag.
- 111 tests pass; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)