### PR TITLE
feat(seo): sitemap lastmod + priority tiers

### DIFF
--- a/app/src/data/server.ts
+++ b/app/src/data/server.ts
@@ -6,7 +6,7 @@
 import { createServerFn } from '@tanstack/react-start'
 import { env } from 'cloudflare:workers'
 import { getStore, type AppEnv } from './store'
-import { getCategory, getChannel, getChannelIndex, getCountry, getEpgMeta, getEpgShard } from './kv'
+import { getCategory, getChannel, getChannelIndex, getCountry, getEpgMeta, getEpgShard, getMeta } from './kv'
 import type { ChannelIndex, EpgShard } from './types'
 
 // getStore ignores env under `vite dev` (returns the fixture); in the built Worker
@@ -29,7 +29,12 @@ export const fetchHomeData = createServerFn({ method: 'GET' }).handler(async () 
   return { ...deriveFacets(index), total: Object.keys(index).length }
 })
 
-export const fetchChannelIndex = createServerFn({ method: 'GET' }).handler(async () => getChannelIndex(store()))
+/** Channel index + snapshot date, for the sitemap route (server-only). */
+export const fetchSitemapData = createServerFn({ method: 'GET' }).handler(async () => {
+  const s = store()
+  const [index, meta] = await Promise.all([getChannelIndex(s), getMeta(s)])
+  return { index, lastmod: meta?.generatedAt ?? null }
+})
 
 /** Resolve only the requested channel ids → their index entries (small payload for
  *  the client rails, rather than shipping the whole index). */

--- a/app/src/lib/sitemap.test.ts
+++ b/app/src/lib/sitemap.test.ts
@@ -31,4 +31,23 @@ describe('buildSitemap', () => {
     expect(xml).toContain('<loc>https://x/</loc>')
     expect(xml).toContain('</urlset>')
   })
+
+  it('emits priority tiers: home 1.0, country/category hubs 0.8, channels 0.5', () => {
+    const xml = buildSitemap('https://x', index)
+    expect(xml).toContain('<loc>https://x/</loc><priority>1.0</priority>')
+    expect(xml).toMatch(/\/country\/gb<\/loc><priority>0\.8<\/priority>/)
+    expect(xml).toMatch(/\/category\/news<\/loc><priority>0\.8<\/priority>/)
+    expect(xml).toMatch(/\/channel\/BBCNews\.uk<\/loc><priority>0\.5<\/priority>/)
+  })
+
+  it('emits a date-only lastmod when a valid generatedAt is passed', () => {
+    const xml = buildSitemap('https://x', index, '2026-07-03T04:00:00.000Z')
+    expect(xml).toContain('<lastmod>2026-07-03</lastmod>')
+    expect(xml).not.toContain('T04:00') // date only, not the full timestamp
+  })
+
+  it('omits lastmod when the date is missing or malformed', () => {
+    expect(buildSitemap('https://x', index)).not.toContain('<lastmod>')
+    expect(buildSitemap('https://x', index, 'not-a-date')).not.toContain('<lastmod>')
+  })
 })

--- a/app/src/lib/sitemap.ts
+++ b/app/src/lib/sitemap.ts
@@ -4,18 +4,30 @@ function xmlEscape(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 }
 
-/** Build a sitemap XML from the channel index: home + per-country/category/channel URLs. */
-export function buildSitemap(origin: string, index: ChannelIndex): string {
-  const urls = new Set<string>([`${origin}/`])
+/**
+ * Build a sitemap XML from the channel index: home + per-country/category/channel URLs.
+ * Priority tiers guide crawl focus — home (1.0) and the country/category hubs (0.8) over
+ * the ~10k long-tail channel pages (0.5). `lastmod` (the snapshot's generatedAt date) is
+ * emitted per URL when it's a valid YYYY-MM-DD so Google knows how fresh the catalog is.
+ */
+export function buildSitemap(origin: string, index: ChannelIndex, lastmod?: string): string {
   const countries = new Set<string>()
   const categories = new Set<string>()
+  const channels: string[] = []
   for (const [id, entry] of Object.entries(index)) {
-    urls.add(`${origin}/channel/${encodeURIComponent(id)}`)
+    channels.push(`${origin}/channel/${encodeURIComponent(id)}`)
     if (entry.country) countries.add(entry.country)
     for (const c of entry.categories) categories.add(c)
   }
-  for (const c of countries) urls.add(`${origin}/country/${encodeURIComponent(c)}`)
-  for (const c of categories) urls.add(`${origin}/category/${encodeURIComponent(c)}`)
-  const body = [...urls].map((u) => `  <url><loc>${xmlEscape(u)}</loc></url>`).join('\n')
-  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${body}\n</urlset>\n`
+
+  const day = lastmod && /^\d{4}-\d{2}-\d{2}/.test(lastmod) ? `<lastmod>${lastmod.slice(0, 10)}</lastmod>` : ''
+  const entry = (loc: string, priority: string) =>
+    `  <url><loc>${xmlEscape(loc)}</loc>${day}<priority>${priority}</priority></url>`
+
+  const lines = [entry(`${origin}/`, '1.0')]
+  for (const c of countries) lines.push(entry(`${origin}/country/${encodeURIComponent(c)}`, '0.8'))
+  for (const c of categories) lines.push(entry(`${origin}/category/${encodeURIComponent(c)}`, '0.8'))
+  for (const loc of channels) lines.push(entry(loc, '0.5'))
+
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${lines.join('\n')}\n</urlset>\n`
 }

--- a/app/src/routes/sitemap[.]xml.tsx
+++ b/app/src/routes/sitemap[.]xml.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { fetchChannelIndex } from '../data/server'
+import { fetchSitemapData } from '../data/server'
 import { buildSitemap } from '../lib/sitemap'
 
 export const Route = createFileRoute('/sitemap.xml')({
@@ -7,7 +7,8 @@ export const Route = createFileRoute('/sitemap.xml')({
     handlers: {
       GET: async ({ request }: { request: Request }) => {
         const origin = new URL(request.url).origin
-        const xml = buildSitemap(origin, await fetchChannelIndex())
+        const { index, lastmod } = await fetchSitemapData()
+        const xml = buildSitemap(origin, index, lastmod ?? undefined)
         return new Response(xml, {
           headers: { 'content-type': 'application/xml; charset=utf-8', 'cache-control': 'public, max-age=3600' },
         })


### PR DESCRIPTION
## What & why

Google just indexed the homepage — this helps it crawl the rest efficiently.

Adds two hints to `/sitemap.xml`:
- **`<priority>`** — home `1.0`, country/category **hubs** `0.8`, the ~10k long-tail **channel** pages `0.5`. Steers Google's crawl budget toward the hubs (which link out to everything) over the thin, similar channel pages — the right shape for a 10k-page catalog site.
- **`<lastmod>`** — the snapshot's `generatedAt` date (date-only, validated `YYYY-MM-DD`), so Google knows how fresh the catalog is and re-crawls after the daily pipeline refresh. Omitted if the date is missing/malformed.

Also folds the sitemap-only `fetchChannelIndex` server fn into `fetchSitemapData` (index + meta in one server boundary; `fetchChannelIndex` had no other callers).

## Testing
- 6 sitemap unit tests (priority tiers, date-only lastmod, omit-when-invalid, existing URL/dedupe coverage); full suite + tsc clean.
- Dev-verified the rendered XML: `home 1.0 / hub 0.8 / channel 0.5`, `<lastmod>` date-only from `meta.generatedAt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)