### PR TITLE
chore(deploy): manual-trigger Cloudflare deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,43 @@
+name: Deploy app
+
+# Manual trigger only — deploy the v2 app (app/) to Cloudflare Workers on demand.
+# Runs the test suite first so a red build never ships. The build inlines the public
+# VITE_GA4_MEASUREMENT_ID via the `deploy` npm script; wrangler authenticates with the
+# CLOUDFLARE_* secrets below.
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: app
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test
+        run: npm run test
+
+      - name: Build & deploy to Cloudflare
+        env:
+          # A Cloudflare API token with the "Edit Cloudflare Workers" permissions
+          # (Workers Scripts:Edit + Workers KV Storage:Edit + Account:Read), and the
+          # account id — wrangler reads both from the environment.
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npm run deploy

--- a/app/package.json
+++ b/app/package.json
@@ -11,7 +11,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",
-    "deploy": "npm run build && wrangler deploy",
+    "deploy": "VITE_GA4_MEASUREMENT_ID=G-VRE57YMEBH npm run build && wrangler deploy",
     "cf-typegen": "wrangler types"
   },
   "dependencies": {


### PR DESCRIPTION
## What

- **`.github/workflows/deploy.yml`** — a **manually-triggered** (`workflow_dispatch`) deploy: `npm ci` → `npm run test` → `npm run deploy` (build + `wrangler deploy`), from `app/`. Runs tests first so a red build never ships. Serialized via a `deploy` concurrency group.
- **`app/package.json`** — the `deploy` script now inlines the public `VITE_GA4_MEASUREMENT_ID` at build time (+ trailing newline).

## Trigger it
GitHub → **Actions → Deploy app → Run workflow** (branch `master`). Or `gh workflow run deploy.yml`.

## ⚠️ Requires two repo secrets (Settings → Secrets and variables → Actions → Secrets)
- **`CLOUDFLARE_API_TOKEN`** — a token with **"Edit Cloudflare Workers"** permissions (Workers Scripts:Edit + Workers KV Storage:Edit + Account Settings:Read). Note: this is **broader than** the pipeline's existing `CF_API_TOKEN` (which only has KV Storage:Edit) — mint a new one from the "Edit Cloudflare Workers" template.
- **`CLOUDFLARE_ACCOUNT_ID`** — `b1b215a14ebf1acd5760d6558992a401`.

wrangler reads both from the environment automatically. Without them the deploy step fails fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)