### PR TITLE
fix(deploy): reuse existing CF_* secrets for wrangler

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,9 +37,11 @@ jobs:
 
       - name: Build & deploy to Cloudflare
         env:
-          # A Cloudflare API token with the "Edit Cloudflare Workers" permissions
-          # (Workers Scripts:Edit + Workers KV Storage:Edit + Account:Read), and the
-          # account id — wrangler reads both from the environment.
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # wrangler reads CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID from the env.
+          # Reuse the existing pipeline secrets (CF_API_TOKEN / CF_ACCOUNT_ID) so no new
+          # secret is needed — but CF_API_TOKEN must carry the "Edit Cloudflare Workers"
+          # permissions (Workers Scripts:Edit + Workers KV Storage:Edit + Account:Read),
+          # which is broader than the KV-only scope the daily pipeline needs.
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
         run: npm run deploy


### PR DESCRIPTION
## Problem

The Node 22 fix worked — the build now succeeds — but `wrangler deploy` fails:
```
it's necessary to set a CLOUDFLARE_API_TOKEN environment variable
```
The workflow read `secrets.CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID`, but the repo has the **pipeline's** secrets: `CF_API_TOKEN`, `CF_ACCOUNT_ID`, `CF_KV_NAMESPACE_ID`.

## Fix
Map the existing `CF_*` secrets to the env vars wrangler reads — **no new secret needed**:
```yaml
CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
```

## ⚠️ One thing to check on the token
`wrangler deploy` uploads a Worker, so `CF_API_TOKEN` needs **Workers Scripts: Edit** (+ Account: Read), which is **broader than** the KV-only scope the daily pipeline needs. If your `CF_API_TOKEN` was created KV-only, the deploy will 403 — fix by editing that token in the Cloudflare dashboard (My Profile → API Tokens → edit → add *Account · Workers Scripts · Edit* and *Account · Account Settings · Read*), or recreate it from the **"Edit Cloudflare Workers"** template (which includes KV + Scripts + Account, covering both the pipeline and deploy).

After merge: re-run **Actions → Deploy app → Run workflow**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)